### PR TITLE
fix: link problem cards to detail pages, fix navigation

### DIFF
--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { activeWorkQueue, pipelineStages, problemHighlights, azureExecutionStats, azureProviderFamilyStats, azureRunTrend, recentAzureRuns, runnableCorrectnessStats, runnableCorrectnessFailures, stageDReadinessStats, stageDReadinessCandidates, stageDExpansionQueue } from '../data/projectStatus';
 
@@ -492,7 +493,7 @@ export default function Home() {
               commands={[
                 'git clone https://github.com/WernerRall147/quantum-grand-challenges.git',
                 'cd quantum-grand-challenges',
-                'dotnet --list-runtimes | findstr 6.0',
+                'pip install qsharp numpy scipy matplotlib',
               ]}
             />
             <CommandBlock
@@ -590,6 +591,10 @@ function statusBadgeStyle(status: string): { text: string; bg: string; fg: strin
 
 function ProblemCard({ title, status, description, href }: ProblemCardProps) {
   const badge = statusBadgeStyle(status);
+  // Extract problem ID from GitHub href to build local route
+  const match = href.match(/problems\/(\d{2}_[a-z_]+)/);
+  const problemId = match ? match[1] : '';
+  const detailHref = problemId ? `/problems/${problemId}/` : href;
   return (
     <div style={{ 
       padding: '1.5rem', 
@@ -610,9 +615,9 @@ function ProblemCard({ title, status, description, href }: ProblemCardProps) {
       </div>
       <p style={{ color: '#0070f3', fontWeight: '600', margin: '0.5rem 0' }}>{status}</p>
       <p style={{ color: '#666', margin: 0 }}>{description}</p>
-      <a href={href} style={{ display: 'inline-block', marginTop: '0.75rem', color: '#0ea5e9', textDecoration: 'none', fontWeight: 600 }}>
-        Open problem folder →
-      </a>
+      <Link href={detailHref} style={{ display: 'inline-block', marginTop: '0.75rem', color: '#0ea5e9', textDecoration: 'none', fontWeight: 600 }}>
+        View details →
+      </Link>
     </div>
   );
 }

--- a/website/pages/problems/[problem].tsx
+++ b/website/pages/problems/[problem].tsx
@@ -74,7 +74,6 @@ function statusBg(status: string): string {
 }
 
 export default function ProblemPage({ problem }: ProblemPageProps) {
-  const basePath = process.env.NODE_ENV === 'production' ? '/quantum-grand-challenges' : '';
   const algorithm = ALGORITHM_MAP[problem.id] || 'Quantum Algorithm';
   const qubits = QUBIT_MAP[problem.id] || '?';
 
@@ -85,7 +84,7 @@ export default function ProblemPage({ problem }: ProblemPageProps) {
         <meta name="description" content={problem.description} />
       </Head>
       <main style={{ maxWidth: '900px', margin: '0 auto', padding: '2rem', fontFamily: 'system-ui, -apple-system, sans-serif' }}>
-        <Link href={`${basePath}/`} style={{ color: '#0070f3', textDecoration: 'none', fontSize: '0.9rem' }}>
+        <Link href="/" style={{ color: '#0070f3', textDecoration: 'none', fontSize: '0.9rem' }}>
           &larr; Back to Dashboard
         </Link>
 
@@ -153,7 +152,7 @@ make run              # Run Q# entry point`}</code>
         </div>
 
         <footer style={{ marginTop: '4rem', padding: '1.5rem 0', borderTop: '1px solid #ddd', textAlign: 'center', color: '#999' }}>
-          <Link href={`${basePath}/`} style={{ color: '#0070f3', textDecoration: 'none' }}>
+          <Link href="/" style={{ color: '#0070f3', textDecoration: 'none' }}>
             Quantum Grand Challenges Dashboard
           </Link>
         </footer>


### PR DESCRIPTION
Fix problem card links on the dashboard to navigate to the per-problem detail pages instead of GitHub.\n\n- ProblemCard extracts problem ID from GitHub href and links to `/problems/XX_name/`\n- Detail page back links use Next.js `Link` (auto-prepends basePath)\n- Replace stale `dotnet --list-runtimes` in Reproduce section with `pip install qsharp`