### PR TITLE
fix: use MngEnv tenant for Azure Quantum SDK + submit 4 emulator jobs

### DIFF
--- a/tooling/azure_submit_kernels.py
+++ b/tooling/azure_submit_kernels.py
@@ -37,38 +37,22 @@ def append_to_history(runs):
     HISTORY_PATH.write_text(json.dumps(history, indent=2), encoding="utf-8")
 
 
-def submit_via_cli(problem_id, target_id, qir_data, shots):
-    """Submit QIR to Azure Quantum via az quantum job submit."""
-    import pyqir
+def submit_via_sdk(problem_id, target_id, qir_data, shots):
+    """Submit QIR to Azure Quantum via Python SDK with CLI credential."""
+    from azure.identity import AzureCliCredential
+    from qdk.azure import Workspace
 
-    # QirInputData stores LLVM IR as _ll_str — convert to bitcode (.bc) for Azure
-    if hasattr(qir_data, "_ll_str"):
-        qir_text = qir_data._ll_str
-    else:
-        qir_text = str(qir_data)
+    RESOURCE_ID = "/subscriptions/82cd08af-0dac-4fc5-8a3a-f2ab9e4679c3/resourceGroups/Quantum-Grand-Challenges/providers/Microsoft.Quantum/Workspaces/Quantum-Grand-Challenges"
 
-    # Parse LLVM IR to Module and write bitcode
-    mod = pyqir.Module.from_ir(pyqir.Context(), qir_text)
-    tmp = tempfile.NamedTemporaryFile(suffix=".bc", delete=False)
-    tmp.write(mod.bitcode)
-    tmp.close()
-    qir_path = tmp.name
     try:
-        cmd = (
-            f'az quantum job submit --target-id {target_id}'
-            f' --job-input-file "{qir_path}"'
-            f' --job-input-format qir.v1'
-            f' --shots {shots}'
-            f' --job-name "qgc-{problem_id}"'
-            f' -o json'
-        )
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60, shell=True)
-        if proc.returncode != 0:
-            return None, proc.stderr[:200]
-        data = json.loads(proc.stdout)
-        return data.get("id", "unknown"), None
-    finally:
-        os.unlink(qir_path)
+        credential = AzureCliCredential(tenant_id="dc692f3e-104b-4247-b52c-23692694684a")
+        workspace = Workspace(resource_id=RESOURCE_ID, location="eastus", credential=credential)
+        target = workspace.get_targets(target_id)
+        job = target.submit(qir_data, f"qgc-{problem_id}", shots=shots)
+        job_id = job.details.id if hasattr(job, "details") else str(job)
+        return job_id, None
+    except Exception as e:
+        return None, str(e)[:200]
 
 
 def main():
@@ -97,7 +81,7 @@ def main():
             print(f"COMPILE FAIL: {str(e)[:120]}"); continue
 
         print("Submitting...", end=" ", flush=True)
-        job_id, err = submit_via_cli(d, target_id, qir, shots)
+        job_id, err = submit_via_sdk(d, target_id, qir, shots)
         if err:
             print(f"FAIL: {err[:100]}")
         else:

--- a/website/data/azureRunHistory.json
+++ b/website/data/azureRunHistory.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_utc": "2026-04-13T18:41:36.131740Z",
+  "updated_utc": "2026-04-13T19:00:38.094756Z",
   "runs": [
     {
       "recorded_utc": "2026-03-04T16:41:55Z",
@@ -888,6 +888,60 @@
       "target_id": "quantinuum.sim.h2-1sc",
       "status": "succeeded",
       "job_id": "bd681510-24a7-4468-85f3-a6f7a5424034"
+    },
+    {
+      "recorded_utc": "2026-04-13T18:52:19.905510Z",
+      "problem_id": "01_hubbard",
+      "instance_id": "small",
+      "depth": 1,
+      "target_id": "quantinuum.sim.h2-1sc",
+      "status": "succeeded",
+      "job_id": "d7a07706-41a3-460a-a7a2-0c234d06dbc9"
+    },
+    {
+      "recorded_utc": "2026-04-13T18:59:01.827353Z",
+      "problem_id": "01_hubbard",
+      "instance_id": "small",
+      "depth": 1,
+      "target_id": "quantinuum.sim.h2-1sc",
+      "status": "succeeded",
+      "job_id": "d28b8380-376a-11f1-bbb8-f068e3583cd5"
+    },
+    {
+      "recorded_utc": "2026-04-13T19:00:07.792943Z",
+      "problem_id": "01_hubbard",
+      "instance_id": "small",
+      "depth": 1,
+      "target_id": "quantinuum.sim.h2-1e",
+      "status": "submitted",
+      "job_id": "fa1c4a43-376a-11f1-ab13-f068e3583cd5"
+    },
+    {
+      "recorded_utc": "2026-04-13T19:00:17.357607Z",
+      "problem_id": "05_qaoa_maxcut",
+      "instance_id": "small",
+      "depth": 1,
+      "target_id": "quantinuum.sim.h2-1e",
+      "status": "submitted",
+      "job_id": "001403bc-376b-11f1-9594-f068e3583cd5"
+    },
+    {
+      "recorded_utc": "2026-04-13T19:00:27.780223Z",
+      "problem_id": "09_factorization",
+      "instance_id": "small",
+      "depth": 1,
+      "target_id": "quantinuum.sim.h2-1e",
+      "status": "submitted",
+      "job_id": "0608c57e-376b-11f1-93f9-f068e3583cd5"
+    },
+    {
+      "recorded_utc": "2026-04-13T19:00:38.094152Z",
+      "problem_id": "16_error_correction",
+      "instance_id": "small",
+      "depth": 1,
+      "target_id": "quantinuum.sim.h2-1e",
+      "status": "submitted",
+      "job_id": "0c788f43-376b-11f1-bdaf-f068e3583cd5"
     }
   ]
 }


### PR DESCRIPTION
Fix Azure Quantum SDK authentication and submit 4 emulator jobs.\n\n### Auth Fix\n- Changed tenant from `72f988bf` (Microsoft corp) to `dc692f3e` (MngEnvMCAP482234) in `azure_submit_kernels.py`\n- Uses `AzureCliCredential(tenant_id='dc692f3e-...')` matching the subscription that hosts the quantum workspace\n- Verified: syntax checker submission Succeeded\n\n### Emulator Jobs Submitted (H2-1E, 100 shots)\n- 01_hubbard (VQE, 2 qubits)\n- 05_qaoa_maxcut (QAOA, optimized γ=0.3, β=1.3)\n- 09_factorization (Shor, 8 qubits)\n- 16_error_correction (QEC, 5 qubits)"