### PR TITLE
fix: standardize test=20/20, update README to 4 Stage D candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Website: <https://wernerrall147.github.io/quantum-grand-challenges/>
 ## 🏁 Latest Milestone (April 2026)
 
 - **All 20 problems at Stage C** with 20-run calibration ensembles and real Azure Quantum Resource Estimator profiles (1.8k–401k physical qubits).
-- **3 Stage D advantage candidates** (QAE, QAOA, Grover) with scaling analysis, fairness reviews, and honest residual risk documentation.
+- **4 Stage D advantage candidates** (QAE, QAOA, Grover DB Search, Grover PQC) with scaling analysis, fairness reviews, and honest residual risk documentation.
 - **Cross-platform emulator validation**: All 20 problems run on Quantinuum H2-1E (100 shots) + 19 on Rigetti QVM (100 shots). **17/19 agree on dominant outcome** — strong cross-platform consistency.
 - **130+ Azure Quantum runs** across 3 systems (Quantinuum H2-1SC, H2-1E, Rigetti QVM).
 - **Noisy simulation study** across all 20 problems at 3 depolarizing error rates (0.001, 0.01, 0.05). Fidelity range: 0.15–0.99.
@@ -266,7 +266,7 @@ See `docs/objective-gates.md` for gate criteria and the required advantage-claim
 | [Drug Discovery](problems/07_drug_discovery/) | ✅ **VQE binding energy** (Pauli Hamiltonian) | ✅ Complete (molecular docking + plots) | ✅ 177k qubits, 12 logical | 🟢 **Stage C** |
 | [Protein Folding](problems/08_protein_folding/) | ✅ **QAOA lattice folding** (contact energy) | ✅ Complete (contact maps + plots) | ✅ 118k qubits, 9 logical | 🟢 **Stage C** |
 | [Factorization](problems/09_factorization/) | ✅ **Shor's algorithm** (QPE + modular multiply, N=15) | ✅ Complete (Pollard's rho + plots) | ✅ 77k qubits, 25 logical | 🟢 **Stage C** |
-| [Post-Quantum Cryptography](problems/10_post_quantum_cryptography/) | ✅ **Grover key search** (80-92% success) | ✅ Complete (attack cost analysis) | ✅ 33k qubits, 12 logical | 🟢 **Stage C** |
+| [Post-Quantum Cryptography](problems/10_post_quantum_cryptography/) | ✅ **Grover key search** (80-83% cross-platform) | ✅ Complete (attack cost analysis) | ✅ 33k qubits, 12 logical | 🟣 **Stage D** (projected) |
 | [Quantum Machine Learning](problems/11_quantum_machine_learning/) | ✅ **Swap test kernel** (5-qubit circuit) | ✅ Complete (kernel methods + plots) | ✅ 153k qubits, 18 logical | 🟢 **Stage C** |
 | [Quantum Optimization](problems/12_quantum_optimization/) | ✅ **QAOA scheduling** (ratio 1.0 optimal) | ✅ Complete (scheduling + plots) | ✅ 132k qubits, 12 logical | 🟢 **Stage C** |
 | [Climate Modeling](problems/13_climate_modeling/) | ✅ **HHL diffusion** (QPE + Trotter) | ✅ Complete (energy balance + plots) | ✅ 130k qubits, 18 logical | 🟢 **Stage C** |

--- a/problems/03_qae_risk/python/test_baseline.py
+++ b/problems/03_qae_risk/python/test_baseline.py
@@ -1,0 +1,48 @@
+"""Deterministic checks for the 03_qae_risk classical baseline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    baseline_path = Path(__file__).resolve().parents[1] / "estimates" / "classical_baseline.json"
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    # Baseline is keyed by threshold (e.g. "2.0", "3.0", "4.0")
+    assert isinstance(payload, dict), "Expected dict keyed by threshold"
+    assert len(payload) >= 1, "Expected at least one threshold entry"
+
+    for threshold_key, data in payload.items():
+        threshold = float(threshold_key)
+        assert threshold > 0, f"Threshold must be positive, got {threshold}"
+
+        precisions = data.get("target_precisions")
+        assert isinstance(precisions, list) and len(precisions) >= 1, (
+            f"Expected target_precisions list for threshold {threshold_key}"
+        )
+
+        estimates = data.get("estimates")
+        assert isinstance(estimates, list), f"Expected estimates list for threshold {threshold_key}"
+        assert len(estimates) == len(precisions), (
+            f"Estimates count {len(estimates)} != precisions count {len(precisions)}"
+        )
+
+        # All estimates should be probabilities in [0, 1]
+        for est in estimates:
+            assert 0.0 <= float(est) <= 1.0, f"Estimate {est} out of [0,1] range"
+
+        # Samples needed should be positive integers
+        samples = data.get("samples_needed")
+        assert isinstance(samples, list) and len(samples) == len(precisions), (
+            f"samples_needed length mismatch for threshold {threshold_key}"
+        )
+        for s in samples:
+            assert int(s) > 0, f"Sample count must be positive, got {s}"
+
+    print("PASS: 03_qae_risk classical baseline checks")
+
+
+if __name__ == "__main__":
+    main()

--- a/problems/05_qaoa_maxcut/python/test_baseline.py
+++ b/problems/05_qaoa_maxcut/python/test_baseline.py
@@ -1,0 +1,46 @@
+"""Deterministic checks for the 05_qaoa_maxcut classical baseline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    baseline_path = Path(__file__).resolve().parents[1] / "estimates" / "classical_baseline.json"
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    assert payload.get("problem_id") == "05_qaoa_maxcut", "Unexpected problem_id"
+    assert payload.get("model") == "exhaustive_maxcut", "Unexpected model"
+
+    results = payload.get("results")
+    assert isinstance(results, list) and len(results) >= 1, "Expected at least one result"
+
+    for row in results:
+        num_nodes = int(row["num_nodes"])
+        num_edges = int(row["num_edges"])
+        best_cut = float(row["best_cut"])
+
+        assert num_nodes >= 2, f"num_nodes must be >= 2, got {num_nodes}"
+        assert num_edges >= 1, f"num_edges must be >= 1, got {num_edges}"
+        assert best_cut >= 0, f"best_cut must be non-negative, got {best_cut}"
+
+        # Best assignments should be binary strings of length num_nodes
+        assignments = row.get("best_assignments", [])
+        assert len(assignments) >= 1, f"Expected at least one best assignment for {row['instance_id']}"
+        for a in assignments:
+            assert len(a) == num_nodes, f"Assignment length {len(a)} != num_nodes {num_nodes}"
+            assert set(a) <= {"0", "1"}, f"Assignment {a} contains non-binary characters"
+
+        # Value histogram should have 2^num_nodes total entries
+        histogram = row.get("value_histogram", {})
+        total_assignments = sum(histogram.values())
+        assert total_assignments == 2 ** num_nodes, (
+            f"Histogram total {total_assignments} != 2^{num_nodes} = {2 ** num_nodes}"
+        )
+
+    print("PASS: 05_qaoa_maxcut classical baseline checks")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

### Test Standardization (20/20)
- Added `test_baseline.py` for **problem 03 (QAE Risk)** — validates threshold keying, probability bounds, sample counts
- Added `test_baseline.py` for **problem 05 (QAOA MaxCut)** — validates graph properties, binary assignments, histogram totals
- pytest now discovers and runs **20/20** baseline tests (was 18/20)
- All 20 pass in 5.73s

### README Update
- Updated milestone: **3 → 4 Stage D advantage candidates** (added PQC Grover)
- Problem 10 PQC row changed from Stage C → **Stage D (projected)** in status table
- Updated implementation description to reference cross-platform validation (80-83%)

### Verification
- ✅ `pytest conftest.py` — 20/20 passed
- ✅ `npm run build` — all 20 SSG pages generated
- ✅ Both new tests verified standalone (`python test_baseline.py` → PASS)