### PR TITLE
fix: website freshness — update stale content, add PQC Stage D evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Website: <https://wernerrall147.github.io/quantum-grand-challenges/>
 - **All 20 problems at Stage C** with 20-run calibration ensembles and real Azure Quantum Resource Estimator profiles (1.8k–401k physical qubits).
 - **4 Stage D advantage candidates** (QAE, QAOA, Grover DB Search, Grover PQC) with scaling analysis, fairness reviews, and honest residual risk documentation.
 - **Cross-platform emulator validation**: All 20 problems run on Quantinuum H2-1E (100 shots) + 19 on Rigetti QVM (100 shots). **17/19 agree on dominant outcome** — strong cross-platform consistency.
-- **130+ Azure Quantum runs** across 3 systems (Quantinuum H2-1SC, H2-1E, Rigetti QVM).
+- **110+ Azure Quantum runs** across 3 systems (Quantinuum H2-1SC, H2-1E, Rigetti QVM).
 - **Noisy simulation study** across all 20 problems at 3 depolarizing error rates (0.001, 0.01, 0.05). Fidelity range: 0.15–0.99.
 - All KPI flags green: `contract=20/20`, `estimator_summary=20/20`, `backend_assumptions=20/20`.
 - Deterministic validation: `build=20/20`, `classical=20/20`, `test=20/20` (24 pytest tests).

--- a/docs/planning/stage-d-readiness-2026-03-10.md
+++ b/docs/planning/stage-d-readiness-2026-03-10.md
@@ -1,24 +1,24 @@
 # Stage D Readiness Audit
 
-Generated: 2026-03-23T11:13:27Z
+Generated: 2026-04-14T12:43:52Z
 
 ## Summary
 
-- Candidate problems: 3
-- Fully ready: 0
-- Average readiness: 83.3%
-- Open checklist items: 0
-- Artifact quality issues: 8
+- Candidate problems: 4
+- Fully ready: 3
+- Average readiness: 95.8%
+- Open checklist items: 3
+- Artifact quality issues: 0
 
 ## 03_qae_risk
 
 - Claim category: expected `projected`, current `projected`
-- Readiness score: 5/6 (83.3%)
+- Readiness score: 6/6 (100.0%)
 - Checklist: total=4, done=4, open=0
 - Artifact checks:
-  - estimates/quantum_estimate_ensemble_small.json: exists=true, listed=true, issues=missing_generated_utc
-  - estimates/quantum_estimate_ensemble_medium.json: exists=true, listed=true, issues=missing_generated_utc
-  - estimates/quantum_estimate_ensemble_large.json: exists=true, listed=true, issues=missing_generated_utc
+  - estimates/quantum_estimate_ensemble_small.json: exists=true, listed=true, issues=none
+  - estimates/quantum_estimate_ensemble_medium.json: exists=true, listed=true, issues=none
+  - estimates/quantum_estimate_ensemble_large.json: exists=true, listed=true, issues=none
   - estimates/fairness_review_stage_d.md: exists=true, listed=true, issues=none
   - estimates/variance_and_overhead_stage_d.json: exists=true, listed=true, issues=none
   - estimates/variance_and_overhead_stage_d.md: exists=true, listed=true, issues=none
@@ -28,11 +28,11 @@ Generated: 2026-03-23T11:13:27Z
 ## 05_qaoa_maxcut
 
 - Claim category: expected `theoretical`, current `theoretical`
-- Readiness score: 5/6 (83.3%)
+- Readiness score: 6/6 (100.0%)
 - Checklist: total=4, done=4, open=0
 - Artifact checks:
-  - estimates/backend_calibration_stage_d.json: exists=true, listed=true, issues=missing_generated_utc
-  - estimates/fairness_benchmark_stage_d.json: exists=true, listed=true, issues=missing_generated_utc
+  - estimates/backend_calibration_stage_d.json: exists=true, listed=true, issues=none
+  - estimates/fairness_benchmark_stage_d.json: exists=true, listed=true, issues=none
   - estimates/fairness_benchmark_stage_d.md: exists=true, listed=true, issues=none
   - estimates/backend_readout_characterization_stage_d.json: exists=true, listed=true, issues=none
   - estimates/backend_readout_characterization_stage_d.md: exists=true, listed=true, issues=none
@@ -40,14 +40,24 @@ Generated: 2026-03-23T11:13:27Z
 ## 15_database_search
 
 - Claim category: expected `projected`, current `projected`
-- Readiness score: 5/6 (83.3%)
+- Readiness score: 6/6 (100.0%)
 - Checklist: total=4, done=4, open=0
 - Artifact checks:
-  - estimates/backend_uncertainty_small.json: exists=true, listed=true, issues=missing_generated_utc
-  - estimates/backend_uncertainty_medium.json: exists=true, listed=true, issues=missing_generated_utc
-  - estimates/backend_uncertainty_large.json: exists=true, listed=true, issues=missing_generated_utc
+  - estimates/backend_uncertainty_small.json: exists=true, listed=true, issues=none
+  - estimates/backend_uncertainty_medium.json: exists=true, listed=true, issues=none
+  - estimates/backend_uncertainty_large.json: exists=true, listed=true, issues=none
   - estimates/oracle_overhead_accounting_stage_d.md: exists=true, listed=true, issues=none
   - estimates/marked_fraction_sensitivity_stage_d.md: exists=true, listed=true, issues=none
   - estimates/backend_readout_characterization_stage_d.json: exists=true, listed=true, issues=none
   - estimates/backend_readout_characterization_stage_d.md: exists=true, listed=true, issues=none
+
+## 10_post_quantum_cryptography
+
+- Claim category: expected `projected`, current `projected`
+- Readiness score: 5/6 (83.3%)
+- Checklist: total=7, done=4, open=3
+- Artifact checks:
+  - estimates/advantage_claim_contract.json: exists=true, listed=true, issues=none
+  - estimates/scaling_analysis_stage_d.json: exists=true, listed=true, issues=none
+  - estimates/stage_d_evidence_summary.json: exists=true, listed=true, issues=none
 

--- a/problems/10_post_quantum_cryptography/STAGE_D_ADVANTAGE_EVIDENCE.md
+++ b/problems/10_post_quantum_cryptography/STAGE_D_ADVANTAGE_EVIDENCE.md
@@ -1,0 +1,59 @@
+# Stage D Advantage Evidence Package - 10_post_quantum_cryptography
+
+## Scope And Claim Boundary
+
+- Problem: Symmetric key search using Grover's algorithm (finding k such that E(k, plaintext) = ciphertext).
+- Current claim category: `projected`.
+- Claim boundary: Asymptotic query scaling (Grover O(√N) vs classical brute-force O(N)).
+- Non-claim boundary: No demonstrated backend wall-clock advantage is claimed. Quadratic speedup only halves effective key length.
+
+## Baseline Fairness Review
+
+- Classical comparator is explicit in `python/classical_baseline.py` and persisted in `estimates/classical_baseline.json`.
+- Brute-force is optimal for unstructured key search (no exploitable structure in properly designed ciphers).
+- Fairness status: pass for query-complexity objective; Grover quadratic speedup is already factored into NIST post-quantum key length recommendations.
+
+## Uncertainty Methodology
+
+- Cross-platform emulator validation: H2-1E 80%, Rigetti QVM 83% success rate (100 shots each).
+- 20-run calibration ensemble with bounded confidence intervals.
+- Noise resilience: 84.1% fidelity at p=0.05 depolarizing noise (3-qubit circuit, 1 Grover iteration).
+
+## Sensitivity And Risk Analysis
+
+- Oracle-synthesis sensitivity:
+  - Real AES/SHA oracle implementation may require millions of T-gates, dramatically increasing resource requirements.
+- Key length scaling:
+  - Quadratic speedup doubles effective key length; NIST already recommends AES-256 (vs AES-128) to counter Grover.
+- Backend sensitivity:
+  - Current evidence is emulator-centric; hardware noise and transpilation effects not yet quantified for production key sizes.
+
+## Backend And Deployment Assumptions
+
+- Azure execution validated on Quantinuum H2-1E and Rigetti QVM emulators.
+- Resource estimate: 32,536 physical qubits for 3-qubit toy instance.
+- Practical AES-128 key search would require O(thousands of logical qubits) and ~2^64 Grover iterations.
+
+## Residual Limitations
+
+- Quadratic speedup only — does not break modern cryptography, only doubles effective key length.
+- Oracle implementation cost for real ciphers is prohibitive with current technology.
+- The practical threat to cryptography comes from Shor's algorithm (factoring), not Grover (search).
+
+## Current Generated Stage D Artifacts
+
+- `estimates/advantage_claim_contract.json`
+- `estimates/scaling_analysis_stage_d.json`
+- `estimates/stage_d_evidence_summary.json`
+- `estimates/resource_estimate.json`
+- `estimates/calibration_ensemble.json`
+
+## Promotion Checklist To `demonstrated`
+
+- [x] File advantage claim contract with explicit category and residual risks.
+- [x] Generate scaling analysis with honest crossover estimates.
+- [x] Cross-platform emulator validation (H2-1E + Rigetti QVM).
+- [x] 20-run calibration ensemble with bounded uncertainty.
+- [ ] Demonstrate on real quantum hardware (H1 QPU) with shot-based confidence intervals.
+- [ ] Integrate realistic AES oracle cost into end-to-end resource analysis.
+- [ ] Compare against quantum-resistant alternatives (lattice-based, hash-based cryptography).

--- a/tooling/reporting/stage_d_readiness_audit.py
+++ b/tooling/reporting/stage_d_readiness_audit.py
@@ -63,6 +63,15 @@ CANDIDATES = [
             "estimates/backend_readout_characterization_stage_d.md",
         ],
     ),
+    CandidateSpec(
+        problem_id="10_post_quantum_cryptography",
+        expected_claim="projected",
+        required_artifacts=[
+            "estimates/advantage_claim_contract.json",
+            "estimates/scaling_analysis_stage_d.json",
+            "estimates/stage_d_evidence_summary.json",
+        ],
+    ),
 ]
 
 

--- a/tooling/reporting/stage_d_readiness_report.json
+++ b/tooling/reporting/stage_d_readiness_report.json
@@ -1,11 +1,11 @@
 {
-  "generated_utc": "2026-03-23T11:13:27Z",
+  "generated_utc": "2026-04-14T12:43:52Z",
   "summary": {
-    "candidate_count": 3,
-    "fully_ready": 0,
-    "avg_readiness_percent": 83.3,
-    "open_checklist_items": 0,
-    "artifact_issue_count": 8
+    "candidate_count": 4,
+    "fully_ready": 3,
+    "avg_readiness_percent": 95.8,
+    "open_checklist_items": 3,
+    "artifact_issue_count": 0
   },
   "candidates": [
     {
@@ -24,25 +24,19 @@
           "path": "estimates/quantum_estimate_ensemble_small.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/quantum_estimate_ensemble_medium.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/quantum_estimate_ensemble_large.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/fairness_review_stage_d.md",
@@ -75,11 +69,11 @@
           "quality_issues": []
         }
       ],
-      "artifact_issue_count": 3,
+      "artifact_issue_count": 0,
       "readiness": {
-        "score": 5,
+        "score": 6,
         "max_score": 6,
-        "percent": 83.3
+        "percent": 100.0
       }
     },
     {
@@ -98,17 +92,13 @@
           "path": "estimates/backend_calibration_stage_d.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/fairness_benchmark_stage_d.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/fairness_benchmark_stage_d.md",
@@ -129,11 +119,11 @@
           "quality_issues": []
         }
       ],
-      "artifact_issue_count": 2,
+      "artifact_issue_count": 0,
       "readiness": {
-        "score": 5,
+        "score": 6,
         "max_score": 6,
-        "percent": 83.3
+        "percent": 100.0
       }
     },
     {
@@ -152,25 +142,19 @@
           "path": "estimates/backend_uncertainty_small.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/backend_uncertainty_medium.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/backend_uncertainty_large.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/oracle_overhead_accounting_stage_d.md",
@@ -197,7 +181,45 @@
           "quality_issues": []
         }
       ],
-      "artifact_issue_count": 3,
+      "artifact_issue_count": 0,
+      "readiness": {
+        "score": 6,
+        "max_score": 6,
+        "percent": 100.0
+      }
+    },
+    {
+      "problem_id": "10_post_quantum_cryptography",
+      "expected_claim": "projected",
+      "current_claim": "projected",
+      "readme_exists": true,
+      "stage_d_file_exists": true,
+      "checklist": {
+        "total": 7,
+        "done": 4,
+        "open": 3
+      },
+      "artifacts": [
+        {
+          "path": "estimates/advantage_claim_contract.json",
+          "exists": true,
+          "listed_in_stage_d_file": true,
+          "quality_issues": []
+        },
+        {
+          "path": "estimates/scaling_analysis_stage_d.json",
+          "exists": true,
+          "listed_in_stage_d_file": true,
+          "quality_issues": []
+        },
+        {
+          "path": "estimates/stage_d_evidence_summary.json",
+          "exists": true,
+          "listed_in_stage_d_file": true,
+          "quality_issues": []
+        }
+      ],
+      "artifact_issue_count": 0,
       "readiness": {
         "score": 5,
         "max_score": 6,

--- a/website/data/problemRunnableCorrectnessReport.json
+++ b/website/data/problemRunnableCorrectnessReport.json
@@ -1,5 +1,5 @@
 {
-  "generated_utc": "2026-03-10T14:30:39Z",
+  "generated_utc": "2026-04-14T12:44:34Z",
   "environment": {
     "make_available": true,
     "dotnet_available": true,
@@ -18,7 +18,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "cd python && C:/Users/weral/Git/quantum-grand-challenges/problems/01_hubbard/../../.venv/Scripts/python.exe classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to C:\\Users\\weral\\Git\\quantum-grand-challenges\\problems\\01_hubbard\\estimates\\classical_baseline.json",
+        "stdout_tail": "cd python && C:/Users/weral/Git/quantum-grand-challenges/problems/01_hubbard/../../.venv/Scripts/python.exe classical_baseline.py\n\u2705 Classical baseline written to C:\\Users\\weral\\Git\\quantum-grand-challenges\\problems\\01_hubbard\\estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -44,7 +44,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "C:/Users/weral/Git/quantum-grand-challenges/problems/02_catalysis/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "C:/Users/weral/Git/quantum-grand-challenges/problems/02_catalysis/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -70,8 +70,8 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Running classical Monte Carlo baseline...\"\ncd python && C:/Users/weral/Git/quantum-grand-challenges/problems/03_qae_risk/../../.venv/Scripts/python.exe classical_baseline.py\n\n=== Analyzing threshold = 2.0 ===\nProbability estimate: 0.244940 \u00c2\u00b1 0.001360\nRuntime: 0.003 seconds\n\n=== Analyzing threshold = 3.0 ===\nProbability estimate: 0.136340 \u00c2\u00b1 0.001085\nRuntime: 0.003 seconds\n\n=== Analyzing threshold = 4.0 ===\nProbability estimate: 0.083390 \u00c2\u00b1 0.000874\nRuntime: 0.003 seconds\n\nResults saved to ..\\estimates\\classical_baseline.json\nPlots saved to ../plots/",
-        "stderr_tail": "C:\\Users\\weral\\Git\\quantum-grand-challenges\\problems\\03_qae_risk\\python\\classical_baseline.py:150: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n  plt.show()\nC:\\Users\\weral\\Git\\quantum-grand-challenges\\problems\\03_qae_risk\\python\\classical_baseline.py:206: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n  plt.show()",
+        "stdout_tail": "\"Running classical Monte Carlo baseline...\"\ncd python && C:/Users/weral/Git/quantum-grand-challenges/problems/03_qae_risk/../../.venv/Scripts/python.exe classical_baseline.py\n\n=== Analyzing threshold = 2.0 ===\nProbability estimate: 0.244940 \u00b1 0.001360\nRuntime: 0.005 seconds\n\n=== Analyzing threshold = 3.0 ===\nProbability estimate: 0.136340 \u00b1 0.001085\nRuntime: 0.001 seconds\n\n=== Analyzing threshold = 4.0 ===\nProbability estimate: 0.083390 \u00b1 0.000874\nRuntime: 0.004 seconds\n\nResults saved to ..\\estimates\\classical_baseline.json\nPlots saved to ../plots/",
+        "stderr_tail": "C:\\Users\\weral\\Git\\quantum-grand-challenges\\problems\\03_qae_risk\\python\\classical_baseline.py:154: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n  plt.show()\nC:\\Users\\weral\\Git\\quantum-grand-challenges\\problems\\03_qae_risk\\python\\classical_baseline.py:210: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n  plt.show()",
         "timed_out": false
       },
       "classical_baseline_json": {
@@ -96,7 +96,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Solving YAML instances with classical dense linear algebra...\"\npython python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Solving YAML instances with classical dense linear algebra...\"\npython python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -122,7 +122,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Running brute-force Max-Cut baselines...\"\npython python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Running brute-force Max-Cut baselines...\"\npython python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -148,7 +148,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Running classical trading baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/06_high_frequency_trading/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Running classical trading baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/06_high_frequency_trading/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -174,7 +174,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Scoring ligand-protein instances...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/07_drug_discovery/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Scoring ligand-protein instances...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/07_drug_discovery/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -200,7 +200,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Scoring protein folding instances with knowledge-based potentials...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/08_protein_folding/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Scoring protein folding instances with knowledge-based potentials...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/08_protein_folding/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -226,7 +226,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Factoring instances with Pollard Rho baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/09_factorization/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Factoring instances with Pollard Rho baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/09_factorization/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -252,7 +252,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Estimating classical and quantum attack costs...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/10_post_quantum_cryptography/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Estimating classical and quantum attack costs...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/10_post_quantum_cryptography/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -278,7 +278,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Evaluating kernel ridge baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/11_quantum_machine_learning/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Evaluating kernel ridge baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/11_quantum_machine_learning/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -304,7 +304,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Evaluating greedy weighted tardiness baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/12_quantum_optimization/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Evaluating greedy weighted tardiness baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/12_quantum_optimization/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -330,7 +330,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Simulating finite-difference diffusion baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/13_climate_modeling/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Simulating finite-difference diffusion baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/13_climate_modeling/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -356,7 +356,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Evaluating surrogate materials baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/14_materials_discovery/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Evaluating surrogate materials baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/14_materials_discovery/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -382,7 +382,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Evaluating classical search baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/15_database_search/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Evaluating classical search baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/15_database_search/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -408,7 +408,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Evaluating repetition-code baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/16_error_correction/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Evaluating repetition-code baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/16_error_correction/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },
@@ -434,7 +434,7 @@
       "classical": {
         "ok": true,
         "returncode": 0,
-        "stdout_tail": "\"Evaluating pionless EFT baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/17_nuclear_physics/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u00e2\u0153\u2026 Classical EFT baseline written to estimates\\classical_baseline.json",
+        "stdout_tail": "\"Evaluating pionless EFT baseline...\"\nC:/Users/weral/Git/quantum-grand-challenges/problems/17_nuclear_physics/../../.venv/Scripts/python.exe python/classical_baseline.py\n\u2705 Classical EFT baseline written to estimates\\classical_baseline.json",
         "stderr_tail": "",
         "timed_out": false
       },

--- a/website/data/stageDReadinessReport.json
+++ b/website/data/stageDReadinessReport.json
@@ -1,11 +1,11 @@
 {
-  "generated_utc": "2026-03-23T11:13:27Z",
+  "generated_utc": "2026-04-14T12:43:52Z",
   "summary": {
-    "candidate_count": 3,
-    "fully_ready": 0,
-    "avg_readiness_percent": 83.3,
-    "open_checklist_items": 0,
-    "artifact_issue_count": 8
+    "candidate_count": 4,
+    "fully_ready": 3,
+    "avg_readiness_percent": 95.8,
+    "open_checklist_items": 3,
+    "artifact_issue_count": 0
   },
   "candidates": [
     {
@@ -24,25 +24,19 @@
           "path": "estimates/quantum_estimate_ensemble_small.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/quantum_estimate_ensemble_medium.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/quantum_estimate_ensemble_large.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/fairness_review_stage_d.md",
@@ -75,11 +69,11 @@
           "quality_issues": []
         }
       ],
-      "artifact_issue_count": 3,
+      "artifact_issue_count": 0,
       "readiness": {
-        "score": 5,
+        "score": 6,
         "max_score": 6,
-        "percent": 83.3
+        "percent": 100.0
       }
     },
     {
@@ -98,17 +92,13 @@
           "path": "estimates/backend_calibration_stage_d.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/fairness_benchmark_stage_d.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/fairness_benchmark_stage_d.md",
@@ -129,11 +119,11 @@
           "quality_issues": []
         }
       ],
-      "artifact_issue_count": 2,
+      "artifact_issue_count": 0,
       "readiness": {
-        "score": 5,
+        "score": 6,
         "max_score": 6,
-        "percent": 83.3
+        "percent": 100.0
       }
     },
     {
@@ -152,25 +142,19 @@
           "path": "estimates/backend_uncertainty_small.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/backend_uncertainty_medium.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/backend_uncertainty_large.json",
           "exists": true,
           "listed_in_stage_d_file": true,
-          "quality_issues": [
-            "missing_generated_utc"
-          ]
+          "quality_issues": []
         },
         {
           "path": "estimates/oracle_overhead_accounting_stage_d.md",
@@ -197,7 +181,45 @@
           "quality_issues": []
         }
       ],
-      "artifact_issue_count": 3,
+      "artifact_issue_count": 0,
+      "readiness": {
+        "score": 6,
+        "max_score": 6,
+        "percent": 100.0
+      }
+    },
+    {
+      "problem_id": "10_post_quantum_cryptography",
+      "expected_claim": "projected",
+      "current_claim": "projected",
+      "readme_exists": true,
+      "stage_d_file_exists": true,
+      "checklist": {
+        "total": 7,
+        "done": 4,
+        "open": 3
+      },
+      "artifacts": [
+        {
+          "path": "estimates/advantage_claim_contract.json",
+          "exists": true,
+          "listed_in_stage_d_file": true,
+          "quality_issues": []
+        },
+        {
+          "path": "estimates/scaling_analysis_stage_d.json",
+          "exists": true,
+          "listed_in_stage_d_file": true,
+          "quality_issues": []
+        },
+        {
+          "path": "estimates/stage_d_evidence_summary.json",
+          "exists": true,
+          "listed_in_stage_d_file": true,
+          "quality_issues": []
+        }
+      ],
+      "artifact_issue_count": 0,
       "readiness": {
         "score": 5,
         "max_score": 6,

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -71,31 +71,31 @@ export default function Home() {
         <section style={{ marginTop: '3rem' }}>
           <h2>📚 Featured Case Studies</h2>
           <p style={{ color: '#666' }}>
-            Stage C implementations now anchor the portfolio while Stage B tracks continue progressing under policy-gated evidence requirements.
+            4 Stage D advantage candidates lead the portfolio. All 20 problems validated on cross-platform emulators (H2-1E + Rigetti QVM).
           </p>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '1.5rem', marginTop: '1.5rem' }}>
             <CaseStudyCard
-              title="QAE Risk Analysis (Stage C Complete)"
+              title="QAE Risk Analysis (Stage D — Theoretical)"
               classicalHeadline="Monte Carlo: 16.1% ± 0.37% (10k samples)"
-              classicalDetails="Classical baseline achieves 0% error vs theoretical for tail risk P(Loss > 2.5) on log-normal(0,1) distribution. Log-normal PDF corrected March 2026."
-              quantumHeadline="Canonical QAE: 594k qubits, 6.4s, 965k T-states"
-              quantumDetails="QAE kernel recalibrated with corrected distribution encoding. Emulator jobs queued on Quantinuum H2-1E for full simulation validation."
+              classicalDetails="Classical baseline achieves 0% error vs theoretical for tail risk P(Loss > 2.5) on log-normal(0,1) distribution. IQAE adaptive driver with Clopper-Pearson CI."
+              quantumHeadline="Canonical QAE: 293k physical qubits, 40 logical"
+              quantumDetails="Cross-platform emulator validation complete: H2-1E + Rigetti QVM. Stage D advantage claim filed (theoretical — quadratic speedup)."
               linkHref="https://github.com/WernerRall147/quantum-grand-challenges/tree/main/problems/03_qae_risk"
             />
             <CaseStudyCard
-              title="Database Search (Stage C Complete)"
+              title="Database Search (Stage D — Projected)"
               classicalHeadline="Search baselines: 16, 32, and 4096-item instances"
-              classicalDetails="Classical search and verification harnesses provide reproducible reference outputs for Grover comparisons."
-              quantumHeadline="Canonical Grover: quadratic search behavior"
-              quantumDetails="Multi-target oracle and measurement validation support the Stage C evidence bundle for database search."
+              classicalDetails="Classical exhaustive search with reproducible verification harness across three instance sizes."
+              quantumHeadline="Canonical Grover: 120k physical qubits, 18 logical"
+              quantumDetails="Provably optimal O(√N) speedup. Cross-platform emulator: 77% H2-1E, 94% Rigetti. Noise degrades to 14.7% fidelity at p=0.05 (deep circuit)."
               linkHref="https://github.com/WernerRall147/quantum-grand-challenges/tree/main/problems/15_database_search"
             />
             <CaseStudyCard
-              title="Hubbard Model (Azure Validated)"
+              title="Hubbard Model (Stage C — Azure Validated)"
               classicalHeadline="Exact diagonalization: Δc = 5.66 at U/t = 4"
               classicalDetails="Two-site half-filled Hubbard model with classical baseline achieving perfect accuracy for ground state energy and Mott gap."
-              quantumHeadline="VQE circuit validated on Quantinuum H2 simulator"
-              quantumDetails="Real VQE ansatz (2-qubit, Ry+CNOT+Rz) submitted to Azure Quantum. Resource estimates generated for surface_code and gate_ns_e3 architectures. Emulator results pending."
+              quantumHeadline="VQE: 177k physical qubits, 12 logical"
+              quantumDetails="2-qubit VQE ansatz validated on H2-1E emulator (68% dominant outcome) and Rigetti QVM (70%). Noise fidelity: 90.5% at p=0.05."
               linkHref="https://github.com/WernerRall147/quantum-grand-challenges/tree/main/problems/01_hubbard"
             />
           </div>

--- a/website/pages/problems/[problem].tsx
+++ b/website/pages/problems/[problem].tsx
@@ -124,6 +124,7 @@ const QUBIT_MAP: Record<string, number> = {
 
 function statusColor(status: string): string {
   const s = status.toLowerCase();
+  if (s.includes('stage d')) return '#7c2d12';
   if (s.includes('stage c')) return '#166534';
   if (s.includes('stage b')) return '#1e40af';
   if (s.includes('azure')) return '#5b21b6';
@@ -132,6 +133,7 @@ function statusColor(status: string): string {
 
 function statusBg(status: string): string {
   const s = status.toLowerCase();
+  if (s.includes('stage d')) return '#fff7ed';
   if (s.includes('stage c')) return '#dcfce7';
   if (s.includes('stage b')) return '#dbeafe';
   if (s.includes('azure')) return '#ede9fe';


### PR DESCRIPTION
## Website Freshness Audit & Fix

Comprehensive audit of all website data files against source data, followed by fixes for stale content.

### Issues Found & Fixed

**Index Page (stale case studies)**
- QAE case study: was "Emulator jobs queued" → now "Cross-platform emulator validation complete"
- Database Search: was "Stage C Complete" → now "Stage D — Projected" with emulator data
- Hubbard: was "Emulator results pending" → now includes H2-1E/Rigetti success rates

**Problem Detail Pages (statusColor)**
- `statusColor()`/`statusBg()` didn't handle Stage D — fell through to default amber
- Now returns distinct orange-brown (#7c2d12 on #fff7ed) for Stage D problems

**Stage D Readiness Report (stale)**
- Was 3 candidates (from March 2026) → now 4 (added PQC)
- Created `STAGE_D_ADVANTAGE_EVIDENCE.md` for problem 10 PQC
- Added PQC to `stage_d_readiness_audit.py` CANDIDATES list
- Regenerated: 4 candidates, 3 fully ready, 95.8% avg readiness

**Other Regenerated Reports**
- `problemRunnableCorrectnessReport.json`: 20/20 passed
- Stage D readiness: 4 candidates (was 3)

**README**
- Run count corrected: "130+" → "110+" to match tracked data (111 runs)

### Verification
- ✅ Website builds successfully (all 20 SSG pages)
- ✅ All data files verified: 20/20 resource estimates, 20/20 calibration, 20 H2-1E + 19 Rigetti emulator results, 20/20 noisy sim
- ✅ pytest 20/20 passed