### PR TITLE
feat: upgrade to model-router + GPT-5.4-mini + GPT-5.3-codex

### DIFF
--- a/agents/classifier/agent.yaml
+++ b/agents/classifier/agent.yaml
@@ -1,6 +1,7 @@
 # Quantum Advantage Classifier Agent
 name: quantum-classifier
-model: gpt-4.1
+model: model-router
+model_fallback: gpt-5.4-mini
 description: |
   Classifies quantum problems by speedup class and applies Troyer's utility-scale filters.
   

--- a/agents/code_generator/agent.yaml
+++ b/agents/code_generator/agent.yaml
@@ -1,6 +1,7 @@
 # Q# Code Generator + Estimator Agent
 name: qsharp-code-generator
-model: gpt-4.1
+model: gpt-5.4-mini
+model_note: gpt-5.3-codex available but requires Responses API (not chat completions)
 description: |
   Generates Q# code for quantum problems, runs resource estimation,
   and optionally submits to Azure Quantum.

--- a/agents/fact_checker/agent.yaml
+++ b/agents/fact_checker/agent.yaml
@@ -1,6 +1,7 @@
 # Fact-Checker Agent
 name: quantum-fact-checker
-model: gpt-4.1
+model: model-router
+model_fallback: gpt-5.4-mini
 description: |
   Validates quantum advantage claims against peer-reviewed literature.
   Applies reality checks: I/O bottleneck, oracle cost, QEC overhead.

--- a/agents/hpc_comparator/agent.yaml
+++ b/agents/hpc_comparator/agent.yaml
@@ -1,6 +1,7 @@
 # HPC Comparator Agent
 name: hpc-comparator
-model: gpt-4.1
+model: model-router
+model_fallback: gpt-5.4-mini
 description: |
   Compares quantum resource requirements against Azure HPC capabilities.
   Uses Microsoft documentation to find the best classical alternative.

--- a/agents/orchestrator/agent.yaml
+++ b/agents/orchestrator/agent.yaml
@@ -3,7 +3,8 @@
 # GenAIOps: Hot-swappable via prompt versioning
 
 name: quantum-advantage-orchestrator
-model: gpt-4.1
+model: model-router
+model_fallback: gpt-5.4-mini
 description: |
   Routes user quantum problems through the evaluation pipeline:
   1. Classify the problem (Classifier Agent)

--- a/infrastructure/.env.template
+++ b/infrastructure/.env.template
@@ -6,10 +6,15 @@ AZURE_SUBSCRIPTION_ID=82cd08af-0dac-4fc5-8a3a-f2ab9e4679c3
 AZURE_TENANT_ID=dc692f3e-104b-4247-b52c-23692694684a
 AZURE_RESOURCE_GROUP=qgc-evaluator
 
-# Azure OpenAI (eastus) — disableLocalAuth enforced, use Entra ID tokens
+# Azure OpenAI — disableLocalAuth enforced, use Entra ID tokens
+# Primary (eastus): gpt-5.4-mini, gpt-5.3-codex, text-embedding-3-large, gpt-4o
 AZURE_OPENAI_ENDPOINT=https://qgc-openai.openai.azure.com/
-AZURE_OPENAI_DEPLOYMENT_CHAT=gpt-4o
+AZURE_OPENAI_DEPLOYMENT_CHAT=gpt-54-mini
+AZURE_OPENAI_DEPLOYMENT_CODEX=gpt-53-codex
 AZURE_OPENAI_DEPLOYMENT_EMBEDDING=text-embedding-3-large
+# Model Router (eastus2): auto-routes to optimal model per request
+AZURE_OPENAI_ROUTER_ENDPOINT=https://admin-mo1q7owo-eastus2.cognitiveservices.azure.com/
+AZURE_OPENAI_ROUTER_DEPLOYMENT=model-router
 # Auth: az account get-access-token --resource "https://cognitiveservices.azure.com"
 
 # Cosmos DB (westus2, serverless)


### PR DESCRIPTION
## Model Upgrade: model-router + GPT-5.4-mini + GPT-5.3-codex

### Deployments

| Deployment | Resource | Model | Purpose |
|-----------|----------|-------|---------|
| `model-router` | admin-mo1q7owo-eastus2 | model-router (2025-11-18) | Auto-routes to optimal model — GenAIOps pattern |
| `gpt-54-mini` | qgc-openai (eastus) | gpt-5.4-mini (2026-03-17) | Chat fallback + code gen |
| `gpt-53-codex` | qgc-openai (eastus) | gpt-5.3-codex (2026-02-24) | Code gen (Responses API only) |
| `text-embedding-3-large` | qgc-openai (eastus) | text-embedding-3-large | KB vector embeddings |

### Agent Assignments

| Agent | Primary | Fallback | Why |
|-------|---------|----------|-----|
| Orchestrator | **model-router** | gpt-5.4-mini | Router auto-selects best model per query complexity |
| Classifier | **model-router** | gpt-5.4-mini | Classification varies — router handles it |
| Fact-Checker | **model-router** | gpt-5.4-mini | Complex reasoning gets routed to stronger models |
| HPC Comparator | **model-router** | gpt-5.4-mini | Simple lookups get cheaper models |
| Code Generator | **gpt-5.4-mini** | — | Codex requires Responses API (planned) |

### Test Results
- ✅ gpt-5.4-mini: tested, responding correctly
- ⏳ model-router: RBAC assigned, propagating (~5 min)
- ℹ️ gpt-5.3-codex: deployed but needs Responses API (not chat completions)