### PR TITLE
fix: deploy workflow — npm install instead of npm ci (lockfile gitignored)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,12 +25,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: website/package-lock.json
 
       - name: Install dependencies
         working-directory: website
-        run: npm ci
+        run: npm install
 
       - name: Build static site
         working-directory: website


### PR DESCRIPTION
The deploy-website.yml workflow has been failing on every run since it was created. All 4 runs show `X` (failure).\n\n**Root cause:** `package-lock.json` is in `.gitignore`, so:\n1. `actions/setup-node` cache fails (lockfile doesn't exist)\n2. `npm ci` fails (requires lockfile)\n\n**Fix:** Remove npm cache config, use `npm install` instead of `npm ci`.\n\nThis should unblock GitHub Pages deployment of the evaluate chat page and all recent website changes.