### PR TITLE
fix: include embedding vectors in AI Search paper upserts

### DIFF
--- a/knowledge/ingest/arxiv_ingester.py
+++ b/knowledge/ingest/arxiv_ingester.py
@@ -171,7 +171,7 @@ def upsert_to_search_index(papers: List[Dict]):
         )
         docs = []
         for p in papers:
-            docs.append({
+            doc = {
                 "id": p["arxiv_id"].replace("/", "_").replace(".", "_"),
                 "arxiv_id": p["arxiv_id"],
                 "title": p["title"],
@@ -179,7 +179,10 @@ def upsert_to_search_index(papers: List[Dict]):
                 "category": p["categories"][0] if p["categories"] else "unknown",
                 "published": p["published"],
                 "authors": ", ".join(p["authors"][:5]),
-            })
+            }
+            if p.get("embedding"):
+                doc["embedding"] = p["embedding"]
+            docs.append(doc)
         result = client.upload_documents(documents=docs)
         succeeded = sum(1 for r in result if r.succeeded)
         print(f"  AI Search: indexed {succeeded}/{len(docs)} papers")


### PR DESCRIPTION
The `upsert_to_search_index()` function was uploading papers without the `embedding` field. The index schema has a `Collection(Edm.Single)` vector field but it was never populated.\n\nNow includes the embedding vector when available, enabling vector/hybrid search on the quantum-papers index.\n\nTested: ran ingester locally, confirmed 18/18 papers have 3072-dim embeddings from text-embedding-3-large.