### PR TITLE
fix(nightly): repair estimation-sweep syntax + restore Cosmos/embeddings auth

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -201,6 +201,12 @@ jobs:
       - name: Run arxiv ingestion
         env:
           SEARCH_ADMIN_KEY: ${{ secrets.SEARCH_ADMIN_KEY }}
+          # DefaultAzureCredential picks these up via EnvironmentCredential,
+          # so Cosmos DB upsert and Azure OpenAI embeddings work on the runner.
+          AZURE_TENANT_ID: dc692f3e-104b-4247-b52c-23692694684a
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_OPENAI_ENDPOINT: https://qgc-openai.openai.azure.com/
         run: python -m knowledge.ingest.arxiv_ingester
 
       - name: Upload ingestion report

--- a/tooling/generate_estimates.py
+++ b/tooling/generate_estimates.py
@@ -12,7 +12,9 @@ from pathlib import Path
 PROBLEMS_DIR = Path(__file__).resolve().parent.parent / "problems"
 
 # Import shared discovery helper
-from discover_problems import discover_all_problems — single-shot kernel operations
+from discover_problems import discover_all_problems
+
+# Single-shot kernel operations per problem
 ENTRY_POINTS = {
     "01_hubbard": "Main.EstimateHubbardEnergy(0.5, 2.0, 1.0, 0.5, 0.3, 1)",
     "02_catalysis": "Main.EstimateMolecularEnergy(1.0, 0.5, 0.3, 1)",


### PR DESCRIPTION
## Why

Five consecutive nightly runs have either failed outright or shown silent index degradation. Investigation surfaced two unrelated root causes - fixed here in one PR so the nightly is green end-to-end.

### Issue 1 - estimation-sweep (hard failure, every night)

tooling/generate_estimates.py line 15 has a stray em-dash (U+2014) mashed into the import line. Job exits immediately with SyntaxError: invalid character 'U+2014'.

### Issue 2 - arxiv-ingestion (silently degraded, looks green)

The job exit code is 0, but the log shows ManagedIdentityCredential failed, embeddings skipped, Cosmos DB upsert failed. For the past 2 weeks we've been writing the AI Search keyword index but not Cosmos DB or vector embeddings. The ingester catches exceptions and continues, masking the failure. Root cause: GitHub runners have no managed identity; DefaultAzureCredential had nothing to fall back to.

## Fix

- tooling/generate_estimates.py: Restored clean import; moved orphaned phrase into a standalone comment.
- .github/workflows/nightly.yml: Pass AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_OPENAI_ENDPOINT to the run step so DefaultAzureCredential -> EnvironmentCredential resolves the same SP already used by deploy-evaluator-api.

No new secrets required.

## Validation

- ast.parse on generate_estimates.py: OK
- yaml.safe_load on nightly.yml: OK
- Real-world validation: trigger Actions -> Nightly -> Run workflow after merge.