### PR TITLE
Fix Cosmos firewall: also toggle publicNetworkAccess + surface upsert failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -221,6 +221,12 @@ jobs:
             --query ipRangeFilter \
             --output tsv)"
           ORIGINAL_IP_FILTER="${ORIGINAL_IP_FILTER//$'\r'/}"
+          ORIGINAL_PUBLIC_ACCESS="$(az cosmosdb show \
+            --resource-group qgc-evaluator \
+            --name qgccosmoseval \
+            --query publicNetworkAccess \
+            --output tsv)"
+          ORIGINAL_PUBLIC_ACCESS="${ORIGINAL_PUBLIC_ACCESS//$'\r'/}"
           if [ -n "${ORIGINAL_IP_FILTER}" ]; then
             NEW_IP_FILTER="${ORIGINAL_IP_FILTER},${RUNNER_IP}"
           else
@@ -228,10 +234,14 @@ jobs:
           fi
           echo "runner_ip=${RUNNER_IP}" >> "$GITHUB_OUTPUT"
           echo "original_ip_filter=${ORIGINAL_IP_FILTER}" >> "$GITHUB_OUTPUT"
-          echo "Adding temporary Cosmos firewall IP ${RUNNER_IP}"
+          echo "original_public_access=${ORIGINAL_PUBLIC_ACCESS}" >> "$GITHUB_OUTPUT"
+          echo "Adding temporary Cosmos firewall IP ${RUNNER_IP} (publicNetworkAccess was ${ORIGINAL_PUBLIC_ACCESS})"
+          # publicNetworkAccess must be Enabled for ipRangeFilter to take effect;
+          # while it is Disabled the public endpoint blocks all traffic, allow-list included.
           az cosmosdb update \
             --resource-group qgc-evaluator \
             --name qgccosmoseval \
+            --public-network-access Enabled \
             --ip-range-filter "${NEW_IP_FILTER}"
 
       - name: Run arxiv ingestion
@@ -250,11 +260,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "Restoring Cosmos firewall IP filter (removing temporary IP ${{ steps.cosmos-fw.outputs.runner_ip }})"
+          ORIGINAL_PUBLIC_ACCESS="${{ steps.cosmos-fw.outputs.original_public_access }}"
+          ORIGINAL_IP_FILTER="${{ steps.cosmos-fw.outputs.original_ip_filter }}"
+          echo "Restoring Cosmos firewall (publicNetworkAccess=${ORIGINAL_PUBLIC_ACCESS}, ipRangeFilter=${ORIGINAL_IP_FILTER})"
           az cosmosdb update \
             --resource-group qgc-evaluator \
             --name qgccosmoseval \
-            --ip-range-filter "${{ steps.cosmos-fw.outputs.original_ip_filter }}"
+            --public-network-access "${ORIGINAL_PUBLIC_ACCESS}" \
+            --ip-range-filter "${ORIGINAL_IP_FILTER}"
 
       - name: Upload ingestion report
         if: always()

--- a/knowledge/ingest/arxiv_ingester.py
+++ b/knowledge/ingest/arxiv_ingester.py
@@ -151,6 +151,7 @@ def upsert_to_cosmos(papers: List[Dict]):
         print(f"  Cosmos DB: upserted {len(papers)} papers")
     except Exception as e:
         print(f"  Cosmos DB upsert failed: {e}")
+        raise
 
 
 def upsert_to_search_index(papers: List[Dict]):


### PR DESCRIPTION
## Why

Nightly run #74 (27196466353) ended with exit 0 but Cosmos DB was never updated. The arxiv-ingestion log shows:

`\nCosmos DB upsert failed: (Forbidden) Request originated from IP 172.208.153.227 through public internet. This is blocked by your Cosmos DB account firewall settings.\n`\n

Root cause: the Cosmos account `qgccosmoseval` has `publicNetworkAccess: Disabled`, which makes the `ipRangeFilter` allow-list a no-op. The Python ingester then caught and discarded the exception, so the job exited cleanly.

## What changed

- `.github/workflows/nightly.yml` (arxiv-ingestion):
  - Capture the current `publicNetworkAccess` in the allow step and set it to `Enabled` alongside the IP allow-list.
  - Restore the original value (`Disabled`) and the original IP filter in the `if: always()` cleanup step.
- `knowledge/ingest/arxiv_ingester.py`: `upsert_to_cosmos` re-raises after logging so future Cosmos failures fail the workflow step instead of silently passing.