### PR TITLE
Remove nightly Stage D trend auto-issue generator

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,47 +101,6 @@ jobs:
         if: steps.create-pr.outcome == 'failure'
         run: echo "::warning::Could not create PR — enable 'Allow GitHub Actions to create and approve pull requests' in repo Settings > Actions > General."
 
-  # Stage D readiness trend
-  stage-d-trend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Baseline + regenerate readiness
-        run: |
-          if [ -f tooling/reporting/stage_d_readiness_report.json ]; then
-            cp tooling/reporting/stage_d_readiness_report.json tooling/reporting/stage_d_readiness_report.baseline.json
-          else
-            python tooling/reporting/stage_d_readiness_audit.py
-            cp tooling/reporting/stage_d_readiness_report.json tooling/reporting/stage_d_readiness_report.baseline.json
-          fi
-          python tooling/reporting/stage_d_readiness_audit.py
-
-      - name: Compute trend + check regression
-        id: trend
-        run: |
-          python tooling/reporting/stage_d_readiness_trend.py \
-            --baseline tooling/reporting/stage_d_readiness_report.baseline.json \
-            --current tooling/reporting/stage_d_readiness_report.json \
-            --out-json tooling/reporting/stage_d_readiness_trend_report.json \
-            --out-md docs/planning/stage-d-readiness-trend.md
-          python -c "
-          import json, os; from pathlib import Path
-          degraded = json.loads(Path('tooling/reporting/stage_d_readiness_trend_report.json').read_text()).get('degraded', False)
-          with Path(os.environ['GITHUB_OUTPUT']).open('a') as f: f.write(f'degraded={str(degraded).lower()}\n')
-          "
-
-      - name: Create regression issue
-        if: steps.trend.outputs.degraded == 'true'
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: 'Stage D readiness regression detected'
-          content-filepath: docs/planning/stage-d-readiness-trend.md
-          labels: reporting,regression
-
   # Runnable/correctness audit (with Q#)
   runnable-correctness:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Removes the nightly `stage-d-trend` job, which was spamming the issue tracker with false "Stage D readiness regression detected" issues — one every night.

### Root cause
The job copied the **checked-in** `stage_d_readiness_report.json` (a stale snapshot from 2026-04-14) as its "baseline", then re-ran a fresh audit and compared. The fresh audit trips over archived-problem evidence paths (post-restructure), so it always looked "degraded" vs the stale baseline → a new issue every night via `peter-evans/create-issue-from-file`.

The job's only consumed output was that issue step (`stage_d_readiness_trend_report.json` and `docs/planning/stage-d-readiness-trend.md` are read nowhere else), so the entire job is removed. It's the nightly sibling of the Stage D readiness gate already removed in PR #124.

### Cleanup done alongside this PR
- Closed all **26** accumulated bot issues (#92–#111, #113, #115, #117, #119, #121, #122) as "not planned" with an explanatory comment.

### Remaining nightly jobs (unchanged)
`estimation-sweep`, `refresh-reports`, `runnable-correctness`, `arxiv-ingestion`.

## Validation
`nightly.yml` parses (YAML OK); confirms PR #124's matrix-freshness warning text is preserved and no `stage-d-trend`/`regression` references remain.

## Follow-up (not in this PR)
The underlying archived-problem readiness drift (stale `stage_d_readiness_report.json` + audit artifact paths) is a separate reporting-accuracy task.