### PR TITLE
Add AI/ML pricing and ground quantum cost analysis to real hardware

### DIFF
--- a/agents/classifier/azure_pricing.py
+++ b/agents/classifier/azure_pricing.py
@@ -117,6 +117,7 @@ QUANTUM_PROVIDER_RATES: Dict[str, Dict[str, Any]] = {
 
 # --- Azure HPC / GPU SKU fallback rates (East US, Pay-as-you-go, USD/hr) ---
 # Refreshed via fetch_azure_compute_rates(); these are the offline fallback.
+# Live retail rates re-verified June 2026 via the Azure Retail Prices API.
 _AZURE_COMPUTE_FALLBACK: Dict[str, Dict[str, Any]] = {
     "Standard_HB176rs_v4": {"usd_per_hour": 7.20, "vcpus": 176, "family": "HPC AMD EPYC"},
     "Standard_HB120rs_v3": {"usd_per_hour": 3.60, "vcpus": 120, "family": "HPC AMD EPYC"},
@@ -124,11 +125,39 @@ _AZURE_COMPUTE_FALLBACK: Dict[str, Dict[str, Any]] = {
     "Standard_ND96amsr_A100_v4": {"usd_per_hour": 27.197, "vcpus": 96, "family": "8x A100 80GB"},
     "Standard_ND96isr_H100_v5": {"usd_per_hour": 98.32, "vcpus": 96, "family": "8x H100 NVLink"},
     "Standard_ND96asr_v4": {"usd_per_hour": 27.20, "vcpus": 96, "family": "8x A100 40GB"},
+    # Azure Machine Learning single-accelerator instance sizes (eastus Linux on-demand).
+    "Standard_DS3_v2": {"usd_per_hour": 0.293, "vcpus": 4, "family": "CPU (Dsv2)"},
+    "Standard_NC4as_T4_v3": {"usd_per_hour": 0.526, "vcpus": 4, "family": "1x T4 16GB"},
+    "Standard_NC24ads_A100_v4": {"usd_per_hour": 3.673, "vcpus": 24, "family": "1x A100 80GB"},
 }
 
 DEFAULT_HPC_SKU = "Standard_HB176rs_v4"
 DEFAULT_GPU_SKU = "Standard_ND96amsr_A100_v4"
 DEFAULT_REGION = "eastus"
+
+# --- Azure Machine Learning instance sizing (rough cost estimate) ---
+# AML compute is billed at the underlying VM hourly rate (no AML surcharge); a
+# small standard load balancer (~$0.33/day per running compute instance) and
+# disk are the only managed add-ons. Idle-shutdown stops the compute-hour meter.
+# See learn.microsoft.com/azure/machine-learning/concept-plan-manage-cost
+AML_INSTANCE_SIZES: Dict[str, str] = {
+    "small": "Standard_DS3_v2",        # CPU dev/inference
+    "medium": "Standard_NC4as_T4_v3",  # single T4 GPU
+    "large": "Standard_NC24ads_A100_v4",  # single A100 80GB GPU
+}
+DEFAULT_AML_INSTANCE = "medium"
+AML_LOAD_BALANCER_USD_PER_DAY = 0.33
+
+# --- Current quantum hardware widths (max usable qubits per device) ---
+# A circuit wider than the device cannot be submitted, so per-shot cost is only
+# meaningful up to this width. Used to keep cost estimates physically grounded.
+QUANTUM_HARDWARE_QUBITS: Dict[str, int] = {
+    "quantinuum_h2": QUANTINUUM_H2["qubits"],
+    "ionq_aria": IONQ_ARIA["qubits"],
+    "ionq_forte": IONQ_FORTE["qubits"],
+    "rigetti_cepheus": RIGETTI_CEPHEUS["qubits"],
+    "pasqal_fresnel": PASQAL_FRESNEL["qubits"],
+}
 
 
 # --- Cache helpers ---
@@ -336,6 +365,50 @@ def estimate_hpc_compute_cost(
     }
 
 
+def estimate_aml_compute_cost(
+    compute_hours: float,
+    instance_size: str = DEFAULT_AML_INSTANCE,
+    region: str = DEFAULT_REGION,
+    use_cache: bool = True,
+) -> Dict[str, Any]:
+    """Cost of running on Azure Machine Learning managed compute.
+
+    AML bills the underlying VM hourly rate (pulled live from the Retail Prices
+    API when reachable) plus a small standard load balancer charge prorated over
+    the job's wall time. ``instance_size`` is one of small | medium | large,
+    mapped to a representative single-accelerator SKU.
+    """
+    size = (instance_size or DEFAULT_AML_INSTANCE).lower()
+    sku = AML_INSTANCE_SIZES.get(size, AML_INSTANCE_SIZES[DEFAULT_AML_INSTANCE])
+    rates_map = fetch_azure_compute_rates([sku], region=region, use_cache=use_cache)
+    rate = rates_map.get(sku) or _AZURE_COMPUTE_FALLBACK.get(sku, {"usd_per_hour": 0.0})
+
+    vm_cost = compute_hours * rate["usd_per_hour"]
+    # Standard load balancer is billed per day; prorate over the run.
+    managed_overhead = AML_LOAD_BALANCER_USD_PER_DAY * (compute_hours / 24.0)
+    total = vm_cost + managed_overhead
+    return {
+        "platform": "azure_ml",
+        "provider": "Azure Machine Learning",
+        "sku": sku,
+        "instance_size": size,
+        "region": region,
+        "estimated_cost_usd": round(total, 2),
+        "vm_cost_usd": round(vm_cost, 2),
+        "managed_overhead_usd": round(managed_overhead, 2),
+        "compute_hours": round(compute_hours, 3),
+        "usd_per_hour": rate["usd_per_hour"],
+        "vcpus": rate.get("vcpus"),
+        "family": rate.get("family", ""),
+        "source": rate.get("source", "static_fallback"),
+        "notes": (
+            f"{rate.get('family', sku)} @ ${rate['usd_per_hour']}/hr billed at the VM rate; "
+            "enable idle-shutdown to stop the compute-hour meter when not training. "
+            "Up to ~72% off with 1-3 yr reserved instances."
+        ),
+    }
+
+
 # --- Algorithm-class-aware default targets ---
 
 ALGORITHM_TO_TARGET = {
@@ -411,11 +484,15 @@ __all__ = [
     "DEFAULT_HPC_SKU",
     "DEFAULT_GPU_SKU",
     "DEFAULT_REGION",
+    "AML_INSTANCE_SIZES",
+    "DEFAULT_AML_INSTANCE",
+    "QUANTUM_HARDWARE_QUBITS",
     "fetch_azure_compute_rates",
     "estimate_quantinuum_hqc_cost",
     "estimate_ionq_cost",
     "estimate_rigetti_cost",
     "estimate_hpc_compute_cost",
+    "estimate_aml_compute_cost",
     "estimate_quantum_cost_for_target",
     "recommended_quantum_target",
 ]

--- a/agents/classifier/cost_model.py
+++ b/agents/classifier/cost_model.py
@@ -19,6 +19,11 @@ COST_MODEL_STATUS = "live_pricing_v1"
 TROYER_PART_6_STATUS = "coming_soon"
 TROYER_PART_6_URL = None
 
+# Representative max circuit depth (gate layers) a current NISQ device can run
+# before decoherence dominates. Used to keep per-shot cost estimates grounded
+# in a hardware-runnable circuit rather than a deep fault-tolerant projection.
+REPRESENTATIVE_NISQ_DEPTH = 1000
+
 # Map orchestrator-level platform IDs onto azure_pricing target keys.
 PLATFORM_TARGET_ALIASES = {
     "azure_quantum_quantinuum_h2": "quantinuum_h2",
@@ -96,6 +101,79 @@ def estimate_hpc_cost(
         "family": detail.get("family"),
         "source": detail.get("source"),
         "notes": f"{detail.get('family', '')} @ ${detail['usd_per_hour']}/hr ({detail.get('source')})",
+    }
+
+
+def estimate_aml_cost(
+    compute_hours: float,
+    instance_size: str = "medium",
+) -> Dict[str, Any]:
+    """Estimate the cost of solving the same problem on Azure Machine Learning.
+
+    AI/ML alternative for problems better served by classical/deep-learning
+    approaches. ``instance_size`` (small | medium | large) maps to a
+    representative single-accelerator AML compute SKU.
+    """
+    detail = azure_pricing.estimate_aml_compute_cost(
+        compute_hours=compute_hours,
+        instance_size=instance_size,
+    )
+    return {
+        "platform": "azure_ml",
+        "provider": detail.get("provider"),
+        "sku": detail.get("sku"),
+        "instance_size": detail.get("instance_size"),
+        "estimated_cost_usd": detail.get("estimated_cost_usd"),
+        "compute_hours": detail.get("compute_hours"),
+        "usd_per_hour": detail.get("usd_per_hour"),
+        "vcpus": detail.get("vcpus"),
+        "family": detail.get("family"),
+        "source": detail.get("source"),
+        "notes": detail.get("notes", ""),
+    }
+
+
+def quantum_hardware_feasibility(
+    physical_qubits: int,
+    target_platform: str = "azure_quantum_quantinuum_h2",
+    logical_depth: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Check whether a circuit of this width/depth can run on today's hardware.
+
+    A fault-tolerant resource estimate (often 10^4 to 10^6 physical qubits and
+    very deep circuits) cannot be submitted to a device that only exposes tens
+    of qubits with limited coherence, so the per-shot dollar figure is only
+    physically meaningful for a hardware-runnable circuit. Returns the device
+    width plus capped width/depth to use for grounded pricing.
+    """
+    target_key = PLATFORM_TARGET_ALIASES.get(target_platform, target_platform)
+    hardware_qubits = azure_pricing.QUANTUM_HARDWARE_QUBITS.get(target_key, 56)
+    width_ok = physical_qubits <= hardware_qubits
+    depth_ok = logical_depth is None or logical_depth <= REPRESENTATIVE_NISQ_DEPTH
+    feasible_today = width_ok and depth_ok
+
+    priced_depth = (
+        min(logical_depth, REPRESENTATIVE_NISQ_DEPTH)
+        if isinstance(logical_depth, int)
+        else None
+    )
+    return {
+        "feasible_today": feasible_today,
+        "estimated_physical_qubits": physical_qubits,
+        "hardware_qubits": hardware_qubits,
+        "priced_circuit_qubits": min(physical_qubits, hardware_qubits),
+        "priced_circuit_depth": priced_depth,
+        "representative_depth_cap": REPRESENTATIVE_NISQ_DEPTH,
+        "note": (
+            f"Runnable today on {target_key} ({hardware_qubits} qubits)."
+            if feasible_today
+            else (
+                f"Fault-tolerant projection needs ~{physical_qubits:,} physical qubits; "
+                f"{target_key} exposes {hardware_qubits}. Cost shown is for a "
+                f"hardware-grounded representative circuit (width and depth capped) "
+                f"at official per-shot rates."
+            )
+        ),
     }
 
 

--- a/agents/orchestrator/evaluate.py
+++ b/agents/orchestrator/evaluate.py
@@ -263,23 +263,30 @@ Provide your evaluation as JSON following the output format specified in your in
 
     @staticmethod
     def _compute_cost_analysis(platform: str, algorithm: str, kb_match: Dict[str, Any]) -> Dict[str, Any]:
-        """Compute order-of-magnitude cost comparison between quantum and classical alternatives.
+        """Compute an order-of-magnitude cost comparison across Quantum, AI/ML, and HPC.
 
-        Uses heuristic resource estimates derived from KB algorithm metadata.
-        This is a Troyer Part 6 placeholder until the formal framework lands.
+        Uses live Azure list pricing (Retail Prices API for compute, official
+        provider formulas for quantum). Quantum per-shot cost is grounded to the
+        device's real qubit width so fault-tolerant projections do not produce
+        physically impossible headline figures.
         """
         try:
             from agents.classifier.cost_model import (
                 estimate_quantum_cost,
                 estimate_hpc_cost,
+                estimate_aml_cost,
                 cost_advantage_ratio,
+                quantum_hardware_feasibility,
                 COST_MODEL_STATUS,
                 TROYER_PART_6_STATUS,
             )
         except ImportError:
             return {"status": "cost_model_unavailable"}
 
-        platform_upper = (platform or "").upper()
+        # Conservative default shot count. The provider per-shot formulas scale
+        # linearly with shots, so a sane default keeps estimates realistic rather
+        # than alarming. 256 shots is a typical sampling run.
+        default_shots = 256
 
         # Pull resource estimate hints from the matched KB algorithm record.
         # Typical fields: physical_qubits, runtime_ns, t_count.
@@ -292,31 +299,67 @@ Provide your evaluation as JSON following the output format specified in your in
         if algorithm and any(a in algorithm.upper() for a in ("VQE", "QAOA", "SWAP")):
             target = "azure_quantum_ionq_aria"
 
+        # Ground the per-shot cost to what the device can actually run. A
+        # fault-tolerant estimate of 10^5-10^6 physical qubits and a very deep
+        # circuit cannot be submitted to a 56-qubit device, so price a
+        # hardware-grounded representative circuit (width and depth capped) and
+        # report feasibility separately.
+        derived_depth = max(1, runtime_ns // 1_000_000)  # ~1 layer per microsecond
+        feasibility = quantum_hardware_feasibility(
+            physical_qubits, target_platform=target, logical_depth=derived_depth
+        )
+        priced_qubits = feasibility["priced_circuit_qubits"]
+        priced_depth = feasibility["priced_circuit_depth"]
+
         quantum = estimate_quantum_cost(
-            physical_qubits=min(physical_qubits, 1_000_000),  # clamp wild estimates
+            physical_qubits=priced_qubits,
             runtime_ns=runtime_ns,
             target_platform=target,
-            shots=1000,
+            shots=default_shots,
+            logical_depth=priced_depth,
         )
+        quantum["feasible_today"] = feasibility["feasible_today"]
+        quantum["feasibility_note"] = feasibility["note"]
 
-        # HPC equivalent: rough rule of thumb  assume an HPC alternative would
-        # solve the same problem in O(seconds-to-minutes) on an A100 cluster
-        # (an over-optimistic comparison favouring HPC).
-        hpc_hours = max(0.1, runtime_ns / 3.6e12)  # ns -> hours
-        hpc = estimate_hpc_cost(compute_hours=hpc_hours, platform="azure_hpc_nd96amsr_a100")
+        # Classical alternatives share the same wall-time assumption: an HPC/AI
+        # alternative would solve the problem in O(seconds-to-minutes) on a
+        # cluster (an over-optimistic comparison favouring classical compute).
+        compute_hours = max(0.1, runtime_ns / 3.6e12)  # ns -> hours
+        hpc = estimate_hpc_cost(compute_hours=compute_hours, platform="azure_hpc_nd96amsr_a100")
+
+        # AI/ML alternative on Azure Machine Learning. Size the instance by the
+        # routed platform: AI/ML problems default to a GPU instance, others to a
+        # lighter one for an order-of-magnitude reference point.
+        aml_instance = "large" if (platform or "").upper() == "AI_ML" else "medium"
+        ai_ml = estimate_aml_cost(compute_hours=compute_hours, instance_size=aml_instance)
 
         ratio = cost_advantage_ratio(quantum, hpc)
+
+        # Pick the cheapest option that is actually runnable today.
+        candidates = [
+            ("quantum", quantum.get("estimated_cost_usd") if feasibility["feasible_today"] else None),
+            ("ai_ml", ai_ml.get("estimated_cost_usd")),
+            ("hpc", hpc.get("estimated_cost_usd")),
+        ]
+        priced = [(name, cost) for name, cost in candidates if isinstance(cost, (int, float))]
+        cheapest = min(priced, key=lambda c: c[1])[0] if priced else None
 
         return {
             "status": COST_MODEL_STATUS,
             "troyer_part_6": TROYER_PART_6_STATUS,
             "recommended_quantum_target": target,
             "quantum_estimate": quantum,
+            "ai_ml_estimate": ai_ml,
             "hpc_estimate": hpc,
             "comparison": ratio,
+            "feasibility": feasibility,
+            "cheapest_runnable": cheapest,
             "caveat": (
-                "Order-of-magnitude estimate based on Azure list pricing. "
-                "Production deployments must validate with az pricing API and full Resource Estimator."
+                "Order-of-magnitude estimate at Azure list pricing "
+                f"({default_shots} shots, hardware-grounded). Quantum figures are "
+                "capped to current device width; fault-tolerant hardware at the "
+                "projected scale is not yet available. Validate with the Azure "
+                "pricing API and the full Resource Estimator before budgeting."
             ),
         }
 

--- a/agents/tests/test_cost_model.py
+++ b/agents/tests/test_cost_model.py
@@ -1,0 +1,78 @@
+"""Unit tests for the cost model: AI/ML pricing + hardware-grounded quantum cost.
+
+Covers the additions that introduced Azure Machine Learning instance-size
+pricing and the feasibility-aware capping that prevents fault-tolerant resource
+estimates from producing physically meaningless headline costs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from agents.classifier import azure_pricing  # noqa: E402
+from agents.classifier.cost_model import (  # noqa: E402
+    REPRESENTATIVE_NISQ_DEPTH,
+    estimate_aml_cost,
+    estimate_quantum_cost,
+    quantum_hardware_feasibility,
+)
+
+
+class TestAmlPricing:
+    def test_provider_and_sku(self):
+        aml = estimate_aml_cost(compute_hours=1.0, instance_size="medium")
+        assert aml["provider"] == "Azure Machine Learning"
+        assert aml["sku"] == azure_pricing.AML_INSTANCE_SIZES["medium"]
+        assert aml["instance_size"] == "medium"
+
+    def test_cost_orders_by_instance_size(self):
+        small = estimate_aml_cost(compute_hours=2.0, instance_size="small")
+        medium = estimate_aml_cost(compute_hours=2.0, instance_size="large")
+        # CPU small must be cheaper than A100 large for the same wall time.
+        assert small["estimated_cost_usd"] < medium["estimated_cost_usd"]
+
+    def test_cost_scales_with_hours(self):
+        one = estimate_aml_cost(compute_hours=1.0, instance_size="medium")
+        ten = estimate_aml_cost(compute_hours=10.0, instance_size="medium")
+        assert ten["estimated_cost_usd"] > one["estimated_cost_usd"]
+
+    def test_unknown_size_falls_back_to_default(self):
+        aml = estimate_aml_cost(compute_hours=1.0, instance_size="enormous")
+        assert aml["sku"] == azure_pricing.AML_INSTANCE_SIZES[azure_pricing.DEFAULT_AML_INSTANCE]
+
+
+class TestHardwareFeasibility:
+    def test_ft_projection_flagged_not_feasible(self):
+        feas = quantum_hardware_feasibility(132_000, "azure_quantum_quantinuum_h2", logical_depth=10_000)
+        assert feas["feasible_today"] is False
+        # Width capped to device, depth capped to the representative NISQ bound.
+        assert feas["priced_circuit_qubits"] == feas["hardware_qubits"]
+        assert feas["priced_circuit_depth"] == REPRESENTATIVE_NISQ_DEPTH
+
+    def test_small_circuit_is_feasible(self):
+        feas = quantum_hardware_feasibility(20, "azure_quantum_ionq_aria", logical_depth=50)
+        assert feas["feasible_today"] is True
+        assert feas["priced_circuit_qubits"] == 20
+        assert feas["priced_circuit_depth"] == 50
+
+
+class TestDeScareGuarantee:
+    def test_fault_tolerant_estimate_stays_bounded(self):
+        """A 1M-qubit FT estimate must not produce an absurd headline cost."""
+        feas = quantum_hardware_feasibility(1_000_000, "azure_quantum_quantinuum_h2", logical_depth=1_000_000)
+        q = estimate_quantum_cost(
+            physical_qubits=feas["priced_circuit_qubits"],
+            runtime_ns=10_000_000_000,
+            target_platform="azure_quantum_quantinuum_h2",
+            shots=256,
+            logical_depth=feas["priced_circuit_depth"],
+        )
+        cost = q["estimated_cost_usd"]
+        assert isinstance(cost, (int, float))
+        # Bounded: grounded to a 56-qubit, depth-capped circuit at official rates.
+        # The pre-fix code produced > $1e12 here.
+        assert cost < 1_000_000

--- a/website/pages/evaluate.tsx
+++ b/website/pages/evaluate.tsx
@@ -67,6 +67,20 @@ interface EvaluationResult {
       provider?: string;
       estimated_cost_usd?: number | null;
       shots?: number;
+      feasible_today?: boolean;
+      feasibility_note?: string;
+      notes?: string;
+    };
+    ai_ml_estimate?: {
+      platform?: string;
+      provider?: string;
+      sku?: string;
+      instance_size?: string;
+      estimated_cost_usd?: number | null;
+      compute_hours?: number;
+      usd_per_hour?: number;
+      family?: string;
+      source?: string;
       notes?: string;
     };
     hpc_estimate?: {
@@ -86,6 +100,13 @@ interface EvaluationResult {
       hpc_cost_usd?: number;
       note?: string;
     };
+    feasibility?: {
+      feasible_today?: boolean;
+      estimated_physical_qubits?: number;
+      hardware_qubits?: number;
+      note?: string;
+    };
+    cheapest_runnable?: string | null;
     caveat?: string;
   };
   bicep_template?: string;
@@ -262,8 +283,8 @@ export default function EvaluatePage() {
               )}
             </div>
 
-            {/* Cost analysis  quantum vs HPC at Azure list pricing */}
-            {result.cost_analysis && (result.cost_analysis.quantum_estimate || result.cost_analysis.hpc_estimate) && (() => {
+            {/* Cost analysis: quantum vs AI/ML vs HPC at Azure list pricing */}
+            {result.cost_analysis && (result.cost_analysis.quantum_estimate || result.cost_analysis.ai_ml_estimate || result.cost_analysis.hpc_estimate) && (() => {
               const ca = result.cost_analysis;
               const v = ca.comparison?.verdict || '';
               const verdictBg =
@@ -281,16 +302,17 @@ export default function EvaluatePage() {
                 v === 'HPC_STRONGLY_PREFERRED'     ? '#b91c1c' :
                                                      '#475569';
               const fmt = (x: number | null | undefined) =>
-                typeof x === 'number' ? `$${x.toLocaleString(undefined, { maximumFractionDigits: 2 })}` : '';
+                typeof x === 'number' ? `$${x.toLocaleString(undefined, { maximumFractionDigits: 2 })}` : 'n/a';
+              const cheapest = ca.cheapest_runnable;
               return (
                 <div style={{ marginBottom: '1.5rem', padding: '1.25rem', background: '#fff', borderRadius: '10px', border: '1px solid #e2e8f0' }}>
-                  <h3 style={{ marginTop: 0, color: '#0f172a' }}>Cost Analysis · Quantum vs HPC</h3>
+                  <h3 style={{ marginTop: 0, color: '#0f172a' }}>Cost Analysis: Quantum vs AI/ML vs HPC</h3>
                   <p style={{ color: '#475569', fontSize: '0.85rem', margin: '0 0 0.75rem' }}>
-                    Live Azure list pricing (quantum providers as of May 2026; HPC SKUs from the Azure Retail Prices API).
+                    Live Azure list pricing: quantum providers per the Azure Quantum pricing page, AI/ML and HPC SKUs from the Azure Retail Prices API. Quantum figures are grounded to current device width and depth, so they reflect a hardware-runnable circuit rather than a fault-tolerant projection.
                   </p>
                   <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '0.75rem' }}>
                     {ca.quantum_estimate && (
-                      <div style={{ padding: '0.85rem 1rem', borderRadius: '8px', background: '#eff6ff', border: '1px solid #bfdbfe' }}>
+                      <div style={{ padding: '0.85rem 1rem', borderRadius: '8px', background: '#eff6ff', border: `1px solid ${cheapest === 'quantum' ? '#2563eb' : '#bfdbfe'}` }}>
                         <div style={{ fontSize: '0.78rem', textTransform: 'uppercase', color: '#1d4ed8', letterSpacing: '0.05em' }}>Quantum</div>
                         <div style={{ fontSize: '1.4rem', fontWeight: 700, color: '#1e3a8a', marginTop: '0.25rem' }}>
                           {fmt(ca.quantum_estimate.estimated_cost_usd)}
@@ -299,10 +321,29 @@ export default function EvaluatePage() {
                           {ca.quantum_estimate.provider || ca.quantum_estimate.platform}
                           {typeof ca.quantum_estimate.shots === 'number' && ` · ${ca.quantum_estimate.shots.toLocaleString()} shots`}
                         </div>
+                        {ca.quantum_estimate.feasible_today === false && (
+                          <div style={{ marginTop: '0.4rem', fontSize: '0.7rem', fontWeight: 600, color: '#9a3412', background: '#ffedd5', borderRadius: '4px', padding: '0.15rem 0.4rem', display: 'inline-block' }}>
+                            Hardware not yet available
+                          </div>
+                        )}
+                      </div>
+                    )}
+                    {ca.ai_ml_estimate && (
+                      <div style={{ padding: '0.85rem 1rem', borderRadius: '8px', background: '#f5f3ff', border: `1px solid ${cheapest === 'ai_ml' ? '#7c3aed' : '#ddd6fe'}` }}>
+                        <div style={{ fontSize: '0.78rem', textTransform: 'uppercase', color: '#6d28d9', letterSpacing: '0.05em' }}>Azure AI / ML</div>
+                        <div style={{ fontSize: '1.4rem', fontWeight: 700, color: '#4c1d95', marginTop: '0.25rem' }}>
+                          {fmt(ca.ai_ml_estimate.estimated_cost_usd)}
+                        </div>
+                        <div style={{ fontSize: '0.8rem', color: '#475569', marginTop: '0.25rem' }}>
+                          {ca.ai_ml_estimate.family || ca.ai_ml_estimate.sku}
+                          {ca.ai_ml_estimate.instance_size && ` · ${ca.ai_ml_estimate.instance_size}`}
+                          {typeof ca.ai_ml_estimate.compute_hours === 'number' && ` · ${ca.ai_ml_estimate.compute_hours.toFixed(2)} hr`}
+                          {typeof ca.ai_ml_estimate.usd_per_hour === 'number' && ` @ $${ca.ai_ml_estimate.usd_per_hour}/hr`}
+                        </div>
                       </div>
                     )}
                     {ca.hpc_estimate && (
-                      <div style={{ padding: '0.85rem 1rem', borderRadius: '8px', background: '#fef3c7', border: '1px solid #fde68a' }}>
+                      <div style={{ padding: '0.85rem 1rem', borderRadius: '8px', background: '#fef3c7', border: `1px solid ${cheapest === 'hpc' ? '#d97706' : '#fde68a'}` }}>
                         <div style={{ fontSize: '0.78rem', textTransform: 'uppercase', color: '#a16207', letterSpacing: '0.05em' }}>Azure HPC / GPU</div>
                         <div style={{ fontSize: '1.4rem', fontWeight: 700, color: '#78350f', marginTop: '0.25rem' }}>
                           {fmt(ca.hpc_estimate.estimated_cost_usd)}
@@ -328,8 +369,13 @@ export default function EvaluatePage() {
                       </div>
                     )}
                   </div>
+                  {ca.feasibility && ca.feasibility.feasible_today === false && ca.feasibility.note && (
+                    <p style={{ marginTop: '0.75rem', marginBottom: 0, fontSize: '0.78rem', color: '#9a3412' }}>
+                      {ca.feasibility.note}
+                    </p>
+                  )}
                   {ca.caveat && (
-                    <p style={{ marginTop: '0.75rem', marginBottom: 0, fontSize: '0.78rem', color: '#64748b', fontStyle: 'italic' }}>
+                    <p style={{ marginTop: '0.5rem', marginBottom: 0, fontSize: '0.78rem', color: '#64748b', fontStyle: 'italic' }}>
                       {ca.caveat}
                     </p>
                   )}


### PR DESCRIPTION
## Summary

Reworks the evaluator's **Cost Analysis** into a grounded, 3-way comparison and fixes the "a thousand shots costs trillions" problem, grounded in official Azure pricing (Microsoft Docs + Azure Retail Prices API).

### 1. Added AI/ML pricing (Azure Machine Learning, by instance size)
Per the AML billing model (compute billed at the underlying VM hourly rate; idle-shutdown stops the meter), with a small standard load-balancer overhead prorated over the run. Instance sizes map to representative single-accelerator SKUs, with live-verified fallback rates (eastus, Linux, on-demand):
- **small** -> `Standard_DS3_v2` (CPU) $0.293/hr
- **medium** -> `Standard_NC4as_T4_v3` (1x T4) $0.526/hr
- **large** -> `Standard_NC24ads_A100_v4` (1x A100 80GB) $3.673/hr

Rates pulled live from the Azure Retail Prices API at runtime; these are the offline fallback.

### 2. Fixed the "trillion dollar" scare
The old path fed a fault-tolerant resource estimate (up to 1M physical qubits) and 1000 shots into the per-shot HQC formula, producing ~$3.6 trillion. Now:
- Quantum per-shot cost is **grounded to the device's real qubit width** and a **representative circuit depth** (you cannot submit a 1M-qubit, 10k-deep circuit to a 56-qubit device).
- Fault-tolerant projections are **labeled "hardware not yet available"** instead of emitting an impossible figure.
- Default shots lowered **1000 -> 256**.

Result for an FT chemistry estimate: **$3.6T -> $39,472** (a real 56-qubit, depth-1000, 256-shot run at official Quantinuum H2 rates), clearly flagged as not runnable today. A genuine NISQ-feasible circuit prices at ~$97.50. AI/ML $0.61-$7.37, HPC $2.72.

### 3. Frontend
`evaluate.tsx` Cost Analysis card is now a 3-way grid (Quantum / Azure AI-ML / Azure HPC) with a cheapest-runnable highlight and a hardware-feasibility note.

### Tests
New `agents/tests/test_cost_model.py` (7 tests): AML provider/SKU/ordering/scaling, feasibility flagging, and a regression guard that the FT estimate stays bounded (< $1M).

## Validation
- 7 cost tests + evaluator smoke pass; all changed Python byte-compiles; website builds with no TS errors.
- Grounded in official sources via Microsoft Docs + Azure MCP retail pricing.
- No `cost_analysis` API change needed (auto-flow dict). No em dashes.