### PR TITLE
Add azure-ai-projects dependency for the Foundry agent path

### DIFF
--- a/agents/api/requirements.txt
+++ b/agents/api/requirements.txt
@@ -3,5 +3,6 @@ uvicorn>=0.30.0
 azure-identity>=1.17.0
 azure-cosmos>=4.7.0
 azure-search-documents>=11.6.0
+azure-ai-projects>=2.2.0
 openai>=1.50.0
 qsharp>=1.27.0


### PR DESCRIPTION
## Why

PR #131 added the opt-in Foundry agent path (`QGC_USE_AGENT=1`), which imports `azure.ai.projects` at runtime in `agents/orchestrator/evaluate.py` (`_evaluate_via_agent`). That dependency was not added to the API image's `requirements.txt`, so the currently deployed image would raise `ModuleNotFoundError: No module named 'azure.ai.projects'` the moment the switch is flipped.

This adds `azure-ai-projects>=2.2.0` so the rebuilt image contains the SDK. Required before enabling `QGC_USE_AGENT=1` on `qgc-eval-api`.

Merging triggers the Deploy Evaluator API workflow, which rebuilds the image (now with the SDK) and updates the Container App. After it deploys, `QGC_USE_AGENT=1` can be set safely.

## Change

- `agents/api/requirements.txt`: add `azure-ai-projects>=2.2.0` (pulls `azure-ai-agents` transitively).