### PR TITLE
Architecture diagram + run-cost guesstimate after code-gen

### DIFF
--- a/agents/api/main.py
+++ b/agents/api/main.py
@@ -73,6 +73,9 @@ class EvaluateResponse(BaseModel):
     bicep_deploy_commands: str = ""
     bicep_post_deploy_note: str = ""
     cost_analysis: dict = {}
+    architecture: dict = {}
+    architecture_diagram: str = ""
+    solution_pricing: dict = {}
 
 
 class CodeRequest(BaseModel):
@@ -165,6 +168,39 @@ def evaluate(request: EvaluateRequest):
                 except Exception as e:  # noqa: BLE001
                     result["bicep_template"] = ""
                     result["bicep_validation"] = {"error": str(e)[:200]}
+
+            # Final steps after code-gen: draw the solution architecture and
+            # guesstimate the run cost. Gated on confidence ("high probability").
+            try:
+                confidence = float(result.get("confidence") or 0.0)
+                min_conf = float(os.environ.get("QGC_ARCH_MIN_CONFIDENCE", "0.6"))
+                if confidence >= min_conf:
+                    from agents.code_generator.architecture import build_architecture
+                    from agents.classifier.cost_model import price_solution
+                    is_quantum = verdict == "QUANTUM_ADVANTAGE" or platform in ("QUANTUM", "HYBRID")
+                    resolved_platform = platform or ("QUANTUM" if is_quantum else "AI_ML")
+                    q_target = (result.get("cost_analysis") or {}).get("recommended_quantum_target") if is_quantum else None
+                    estimation = result.get("estimation") or {}
+                    arch = build_architecture(
+                        platform=resolved_platform,
+                        algorithm=result.get("recommended_algorithm", ""),
+                        estimation=estimation,
+                        quantum_target=q_target,
+                        confidence=confidence,
+                    )
+                    result["architecture"] = arch
+                    result["architecture_diagram"] = arch.get("mermaid", "")
+                    result["solution_pricing"] = price_solution(
+                        platform=resolved_platform,
+                        algorithm=result.get("recommended_algorithm", ""),
+                        estimation=estimation,
+                        quantum_target=q_target,
+                    )
+            except Exception as e:  # noqa: BLE001
+                result.setdefault("architecture", {})
+                result.setdefault("architecture_diagram", "")
+                result.setdefault("solution_pricing", {"error": str(e)[:200]})
+
         return EvaluateResponse(**{k: result.get(k, EvaluateResponse.model_fields[k].default)
                                    for k in EvaluateResponse.model_fields})
     except Exception as e:

--- a/agents/classifier/cost_model.py
+++ b/agents/classifier/cost_model.py
@@ -212,3 +212,84 @@ def cost_advantage_ratio(
         "verdict": verdict,
         "note": "Cost alone does not determine advantage. Speedup class and problem scale matter. See Troyer Part 6.",
     }
+
+
+def price_solution(
+    platform: str,
+    algorithm: str = "",
+    estimation: Optional[Dict[str, Any]] = None,
+    quantum_target: Optional[str] = None,
+    shots: int = 256,
+) -> Dict[str, Any]:
+    """Price the *generated* solution on its recommended platform.
+
+    Unlike ``cost_advantage_ratio`` (a 3-way comparison seeded from KB
+    defaults), this uses the actual code-generator ``estimation``
+    (physical_qubits, runtime_ns) to answer "what would it cost to run THIS
+    solution, and is it runnable on today's hardware?". For quantum it reports
+    the qubit-availability crossover from ``quantum_hardware_feasibility``.
+    """
+    platform = (platform or "").upper()
+    estimation = estimation or {}
+    runtime_ns = int(estimation.get("runtime_ns") or 0)
+
+    if platform in ("QUANTUM", "HYBRID") or quantum_target:
+        physical_qubits = int(estimation.get("physical_qubits") or 0) or 100
+        target = quantum_target or "azure_quantum_quantinuum_h2"
+        derived_depth = max(1, (runtime_ns or 1_000_000) // 1_000_000)
+        feas = quantum_hardware_feasibility(
+            physical_qubits, target_platform=target, logical_depth=derived_depth
+        )
+        cost = estimate_quantum_cost(
+            physical_qubits=feas["priced_circuit_qubits"],
+            runtime_ns=runtime_ns or 1_000_000,
+            target_platform=target,
+            shots=shots,
+            logical_depth=feas["priced_circuit_depth"],
+        )
+        return {
+            "platform": "QUANTUM",
+            "recommended_target": target,
+            "provider": cost.get("provider"),
+            "estimated_run_cost_usd": cost.get("estimated_cost_usd"),
+            "shots": shots,
+            "basis": (
+                f"{shots} shots on {cost.get('provider')} at official per-shot rates, "
+                "circuit width and depth grounded to the device."
+            ),
+            "feasible_today": feas["feasible_today"],
+            "qubits_needed": feas["estimated_physical_qubits"],
+            "qubits_available_today": feas["hardware_qubits"],
+            "crossover_note": feas["note"],
+            "status": COST_MODEL_STATUS,
+            "troyer_part_6": TROYER_PART_6_STATUS,
+        }
+
+    if platform == "HPC":
+        compute_hours = max(0.1, (runtime_ns or 3_600_000_000_000) / 3.6e12)
+        cost = estimate_hpc_cost(compute_hours=compute_hours)
+        return {
+            "platform": "HPC",
+            "estimated_run_cost_usd": cost.get("estimated_cost_usd"),
+            "sku": cost.get("sku"),
+            "compute_hours": cost.get("compute_hours"),
+            "basis": cost.get("notes"),
+            "feasible_today": True,
+            "status": COST_MODEL_STATUS,
+        }
+
+    # AI/ML (default for any non-quantum, non-HPC recommendation)
+    compute_hours = max(0.1, (runtime_ns or 3_600_000_000_000) / 3.6e12)
+    cost = estimate_aml_cost(
+        compute_hours=compute_hours,
+        instance_size="large" if platform == "AI_ML" else "medium",
+    )
+    return {
+        "platform": platform or "AI_ML",
+        "estimated_run_cost_usd": cost.get("estimated_cost_usd"),
+        "sku": cost.get("sku"),
+        "compute_hours": cost.get("compute_hours"),
+        "basis": cost.get("notes"),
+        "feasible_today": True,
+        "status": COST_MODEL_STATUS,
+    }

--- a/agents/code_generator/architecture.py
+++ b/agents/code_generator/architecture.py
@@ -1,0 +1,156 @@
+"""Solution architecture diagrams (Mermaid) for a recommended platform.
+
+After the evaluator picks a platform and the code generator produces code +
+resource estimates, this renders a deployable Azure architecture as a Mermaid
+flowchart, grounded in the actual recommendation (target quantum hardware +
+qubit width, or HPC/AI-ML compute SKUs). Paired with ``price_solution`` it
+answers "what would I build, and what would it cost to run?".
+
+This is the deterministic baseline (Increment 1). Roadmap is tracked in
+docs/initiatives/architecture-pricing.md: Increment 2 lets the Foundry agent
+enrich the diagram from Azure Architecture Center via the Microsoft Learn MCP.
+"""
+
+from typing import Any, Dict, Optional
+
+from agents.classifier import azure_pricing
+
+# Map orchestrator quantum-target ids onto azure_pricing provider keys.
+_QTARGET_ALIASES = {
+    "azure_quantum_quantinuum_h2": "quantinuum_h2",
+    "quantinuum_h2": "quantinuum_h2",
+    "azure_quantum_ionq_aria": "ionq_aria",
+    "ionq_aria": "ionq_aria",
+    "azure_quantum_ionq_forte": "ionq_forte",
+    "ionq_forte": "ionq_forte",
+    "azure_quantum_rigetti": "rigetti_cepheus",
+    "rigetti_cepheus": "rigetti_cepheus",
+    "azure_quantum_pasqal": "pasqal_fresnel",
+    "pasqal_fresnel": "pasqal_fresnel",
+}
+
+
+def _hardware(target: Optional[str]):
+    """Return (display_name, qubits) for a quantum target id."""
+    key = _QTARGET_ALIASES.get(target or "", target or "quantinuum_h2")
+    rec = azure_pricing.QUANTUM_PROVIDER_RATES.get(key, azure_pricing.QUANTINUUM_H2)
+    return rec.get("name", "Quantinuum H2-1"), int(rec.get("qubits", 56))
+
+
+def _quantum_mermaid(algorithm: str, hw_name: str, hw_qubits: int) -> str:
+    algo = algorithm or "QPE"
+    return "\n".join(
+        [
+            "flowchart LR",
+            '    user["Researcher / client"] --> api["Azure Container App<br/>Evaluator API"]',
+            f'    api --> orch["Classical orchestrator<br/>{algo} driver (Python + QDK)"]',
+            '    orch --> aqw["Azure Quantum workspace"]',
+            f'    aqw --> hw["{hw_name}<br/>{hw_qubits} qubits (QPU)"]',
+            '    orch --> est["Azure Quantum<br/>Resource Estimator"]',
+            '    aqw --> store["Azure Storage<br/>job results"]',
+            '    api --> kv["Key Vault<br/>secrets"]',
+            '    orch --> mon["Azure Monitor<br/>+ App Insights"]',
+        ]
+    )
+
+
+def _hpc_mermaid(sku_label: str) -> str:
+    return "\n".join(
+        [
+            "flowchart LR",
+            '    user["Researcher / client"] --> cc["Azure CycleCloud"]',
+            '    cc --> sched["Slurm scheduler"]',
+            f'    sched --> nodes["{sku_label}<br/>MPI / GPU cluster"]',
+            '    nodes --> lustre["Azure Managed Lustre<br/>scratch"]',
+            '    nodes --> blob["Blob Storage<br/>datasets + results"]',
+            '    cc --> mon["Azure Monitor"]',
+        ]
+    )
+
+
+def _aiml_mermaid(sku_label: str) -> str:
+    return "\n".join(
+        [
+            "flowchart LR",
+            '    user["Researcher / client"] --> foundry["Azure AI Foundry<br/>project"]',
+            f'    foundry --> compute["{sku_label}<br/>training / inference compute"]',
+            '    compute --> pipe["ML pipeline<br/>(PyTorch / fine-tune)"]',
+            '    foundry --> data["Azure Data Lake<br/>training data"]',
+            '    foundry --> reg["Model registry"]',
+            '    foundry --> mon["Azure Monitor<br/>+ App Insights"]',
+        ]
+    )
+
+
+def build_architecture(
+    platform: str,
+    algorithm: str = "",
+    estimation: Optional[Dict[str, Any]] = None,
+    quantum_target: Optional[str] = None,
+    confidence: float = 0.0,
+    hpc_sku_label: str = "HBv4 / ND A100 v4 nodes",
+    aiml_sku_label: str = "NC A100 v4 GPU compute",
+) -> Dict[str, Any]:
+    """Build a grounded Mermaid architecture for the recommended platform.
+
+    Returns ``{platform, mermaid, components, narrative, confidence}``. The
+    diagram is deterministic and tied to the recommendation so it pairs 1:1 with
+    the run-cost estimate from ``cost_model.price_solution``.
+    """
+    platform = (platform or "").upper()
+    estimation = estimation or {}
+
+    if platform in ("QUANTUM", "HYBRID") or quantum_target:
+        hw_name, hw_qubits = _hardware(quantum_target)
+        mermaid = _quantum_mermaid(algorithm, hw_name, hw_qubits)
+        components = [
+            "Azure Container App (evaluator API entry point)",
+            f"Classical orchestrator running the {algorithm or 'QPE'} driver (QDK)",
+            "Azure Quantum workspace",
+            f"{hw_name} QPU target ({hw_qubits} qubits)",
+            "Azure Quantum Resource Estimator",
+            "Azure Storage for job results, Key Vault for secrets, Azure Monitor",
+        ]
+        narrative = (
+            f"Hybrid quantum-classical solution: a classical orchestrator drives the "
+            f"{algorithm or 'QPE'} circuit and submits jobs to the {hw_name} QPU "
+            f"({hw_qubits} qubits) through an Azure Quantum workspace. The Resource "
+            f"Estimator sizes the fault-tolerant requirement; results land in Storage."
+        )
+    elif platform == "HPC":
+        mermaid = _hpc_mermaid(hpc_sku_label)
+        components = [
+            "Azure CycleCloud orchestration",
+            "Slurm scheduler",
+            f"{hpc_sku_label} compute cluster",
+            "Azure Managed Lustre scratch + Blob Storage",
+            "Azure Monitor",
+        ]
+        narrative = (
+            f"Classical HPC solution: Azure CycleCloud provisions a Slurm-scheduled "
+            f"{hpc_sku_label} cluster for MPI/GPU compute, with Managed Lustre scratch "
+            f"and Blob Storage for datasets and results."
+        )
+    else:  # AI_ML and anything else
+        platform = platform or "AI_ML"
+        mermaid = _aiml_mermaid(aiml_sku_label)
+        components = [
+            "Azure AI Foundry project",
+            f"{aiml_sku_label}",
+            "ML training / inference pipeline",
+            "Azure Data Lake + Model registry",
+            "Azure Monitor",
+        ]
+        narrative = (
+            f"AI/ML solution: an Azure AI Foundry project orchestrates training and "
+            f"inference on {aiml_sku_label}, with a Data Lake for training data and a "
+            f"model registry for versioning."
+        )
+
+    return {
+        "platform": platform,
+        "mermaid": mermaid,
+        "components": components,
+        "narrative": narrative,
+        "confidence": round(float(confidence or 0.0), 3),
+    }

--- a/docs/initiatives/architecture-pricing.md
+++ b/docs/initiatives/architecture-pricing.md
@@ -1,0 +1,73 @@
+# Initiative: Solution Architecture + Pricing
+
+Living tracker for the "after code-gen, draw the architecture and price the run" capability.
+Improve this piece by piece as new quantum hardware ships and Azure best practices change.
+
+## Goal
+
+After the evaluator picks a platform (with high confidence) and the code generator
+produces code + resource estimates, automatically:
+
+1. **Draw the solution architecture** (Mermaid) grounded in the real recommendation
+   (target quantum hardware + qubit count, or HPC/AI-ML VM SKUs).
+2. **Guesstimate the run cost** of that specific solution using the pricing calculator,
+   including the qubit-availability crossover (at what hardware width quantum becomes
+   runnable / cheaper).
+
+Example: "Simulate the ground state energy of a 50-atom lithium cobalt oxide battery
+cathode material" at 88% confidence -> draw the Azure Quantum architecture, then price
+a representative run and state when it becomes feasible on real hardware.
+
+## Status (2026-06-15)
+
+| Piece | State |
+| --- | --- |
+| Pricing calculator (cost_model + azure_pricing) | DONE, verified live |
+| Qubit-availability crossover (`quantum_hardware_feasibility`) | DONE (baseline) |
+| Architecture generator (deterministic Mermaid, grounded) | Increment 1 |
+| Solution pricing (`price_solution`, uses real resource estimate) | Increment 1 |
+| API wiring (`/api/evaluate` returns `architecture_diagram` + `solution_pricing`) | Increment 1 |
+| Website rendering (Mermaid + pricing card) | Increment 1 |
+| Agent + Microsoft Learn / Azure Architecture Center enrichment | Increment 2 (roadmap) |
+| Per-hardware crossover table refresh as devices ship | Ongoing |
+
+## Architecture: deterministic baseline first
+
+Increment 1 uses deterministic, grounded Mermaid templates per platform
+(`agents/code_generator/architecture.py`). This is reliable and testable and ties
+directly to the resource estimate. The agent (Foundry, model-router) already has the
+Microsoft Learn MCP tool; Increment 2 will let it enrich the diagram with Azure
+Architecture Center reference patterns.
+
+## Pricing: tied to the generated solution
+
+`price_solution` (in `agents/classifier/cost_model.py`) prices the recommended
+platform using the real code-gen `estimation` (physical_qubits, runtime_ns) rather
+than KB defaults, and reports the qubit crossover from `quantum_hardware_feasibility`.
+
+## Qubit-availability crossover
+
+`azure_pricing.QUANTUM_HARDWARE_QUBITS` holds current device widths. As new hardware
+ships (more qubits, better fidelity, lower per-shot price), update:
+
+- `agents/classifier/azure_pricing.py`: `QUANTUM_HARDWARE_QUBITS` and per-provider rates
+- `agents/classifier/cost_model.py`: `REPRESENTATIVE_NISQ_DEPTH` if coherence improves
+
+The crossover answer ("feasible_today" + "needs N qubits, hardware has M") then updates
+automatically.
+
+## Roadmap / next increments
+
+- **Increment 2**: agent-enriched architecture using Microsoft Learn MCP +
+  Azure Architecture Center patterns (add an Azure MCP or a curated reference index).
+- **Increment 3**: cost-vs-qubit-count curve (plot run cost as device width grows to the
+  required scale) so the crossover point is visual.
+- **Increment 4**: include data-loading (I/O) and error-correction overhead in the
+  run-cost estimate, aligned with Troyer Part 6 once published.
+- **Ongoing**: refresh `QUANTUM_HARDWARE_QUBITS` and provider rates per hardware release.
+
+## Data sources to wire in
+
+- Azure Retail Prices API (already used by `azure_pricing`).
+- Azure Quantum pricing page (learn.microsoft.com/azure/quantum/pricing).
+- Azure Architecture Center (via Microsoft Learn MCP) for reference architectures.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/material": "^5.14.0",
         "d3": "^7.8.5",
+        "mermaid": "^11.4.0",
         "next": "^14.0.0",
         "plotly.js": "^2.26.0",
         "react": "^18.0.0",
@@ -26,6 +27,19 @@
         "eslint": "^8.0.0",
         "eslint-config-next": "^14.0.0",
         "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -166,6 +180,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@choojs/findup": {
       "version": "0.2.1",
@@ -466,6 +492,23 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -662,6 +705,15 @@
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
+      }
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.18.0",
@@ -1338,10 +1390,72 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -1350,10 +1464,83 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -1371,6 +1558,24 @@
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -1379,6 +1584,18 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.7",
@@ -1395,11 +1612,36 @@
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -1540,6 +1782,13 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.46.1",
@@ -2087,6 +2336,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -3080,6 +3339,15 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -3255,6 +3523,54 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
       "license": "MIT"
     },
     "node_modules/d": {
@@ -3599,6 +3915,46 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -3717,6 +4073,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3777,6 +4143,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3889,6 +4261,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/draw-svg-path": {
@@ -4200,6 +4581,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
+      "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es5-ext": {
       "version": "0.10.64",
@@ -5650,6 +6041,12 @@
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5849,6 +6246,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -6585,6 +6992,31 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
@@ -6600,6 +7032,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -6629,6 +7066,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -6684,6 +7127,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6855,6 +7304,18 @@
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6890,6 +7351,41 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7386,6 +7882,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7441,6 +7943,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
       "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -7686,6 +8194,22 @@
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
       "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
       "license": "MIT"
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
     },
     "node_modules/polybooljs": {
       "version": "1.2.2",
@@ -8304,6 +8828,18 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -9296,6 +9832,15 @@
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -9409,6 +9954,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -9688,6 +10242,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.0.0",
     "recharts": "^2.8.0",
     "d3": "^7.8.5",
+    "mermaid": "^11.4.0",
     "@mui/material": "^5.14.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",

--- a/website/pages/evaluate.tsx
+++ b/website/pages/evaluate.tsx
@@ -1,6 +1,36 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
+
+// Renders a Mermaid diagram client-side. Falls back to the diagram source on
+// any render error so the architecture is always visible.
+function MermaidDiagram({ chart }: { chart: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const mermaid = (await import('mermaid')).default;
+        mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'loose' });
+        const id = 'mmd-' + Math.random().toString(36).slice(2);
+        const { svg } = await mermaid.render(id, chart);
+        if (!cancelled && ref.current) ref.current.innerHTML = svg;
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [chart]);
+  if (failed) {
+    return (
+      <pre style={{ margin: 0, color: '#7dd3fc', fontSize: '0.8rem', overflow: 'auto', padding: '0.75rem', background: '#020617', borderRadius: '6px' }}>
+        {chart}
+      </pre>
+    );
+  }
+  return <div ref={ref} style={{ overflow: 'auto', textAlign: 'center' }} />;
+}
 
 interface TroyerFilters {
   F1_proven_speedup?: boolean;
@@ -113,6 +143,29 @@ interface EvaluationResult {
   bicep_validation?: { validated?: boolean; error?: string; skipped?: boolean; reason?: string };
   bicep_deploy_commands?: string;
   bicep_post_deploy_note?: string;
+  architecture?: {
+    platform?: string;
+    mermaid?: string;
+    components?: string[];
+    narrative?: string;
+    confidence?: number;
+  };
+  architecture_diagram?: string;
+  solution_pricing?: {
+    platform?: string;
+    recommended_target?: string;
+    provider?: string;
+    estimated_run_cost_usd?: number | null;
+    shots?: number;
+    basis?: string;
+    feasible_today?: boolean;
+    qubits_needed?: number;
+    qubits_available_today?: number;
+    crossover_note?: string;
+    sku?: string;
+    compute_hours?: number;
+    status?: string;
+  };
 }
 
 const EXAMPLE_PROBLEMS = [
@@ -628,6 +681,69 @@ export default function EvaluatePage() {
                 {result.bicep_post_deploy_note && (
                   <p style={{ marginTop: '0.5rem', color: '#94a3b8', fontSize: '0.82rem', fontStyle: 'italic' }}>
                     💡 {result.bicep_post_deploy_note}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Final step 1: solution architecture (Mermaid), grounded in the recommendation */}
+            {result.architecture_diagram && (
+              <div style={{ marginBottom: '1.5rem', padding: '1.25rem', background: '#0f172a', borderRadius: '10px', border: '1px solid #1e293b' }}>
+                <h3 style={{ marginTop: 0, color: '#e2e8f0' }}>
+                  🗺️ Solution Architecture
+                  {typeof result.architecture?.confidence === 'number' && (
+                    <span style={{ marginLeft: '0.5rem', fontSize: '0.8rem', color: '#94a3b8' }}>
+                      ({Math.round((result.architecture.confidence || 0) * 100)}% confidence)
+                    </span>
+                  )}
+                </h3>
+                {result.architecture?.narrative && (
+                  <p style={{ color: '#94a3b8', fontSize: '0.85rem', margin: '0 0 0.75rem' }}>
+                    {result.architecture.narrative}
+                  </p>
+                )}
+                <div style={{ background: '#020617', borderRadius: '6px', padding: '0.75rem' }}>
+                  <MermaidDiagram chart={result.architecture_diagram} />
+                </div>
+                {result.architecture?.components && result.architecture.components.length > 0 && (
+                  <ul style={{ color: '#cbd5e1', fontSize: '0.82rem', marginTop: '0.75rem', lineHeight: 1.6 }}>
+                    {result.architecture.components.map((c, i) => <li key={i}>{c}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {/* Final step 2: run-cost guesstimate for the generated solution */}
+            {result.solution_pricing && typeof result.solution_pricing.estimated_run_cost_usd !== 'undefined' && (
+              <div style={{ marginBottom: '1.5rem', padding: '1.25rem', background: '#0f172a', borderRadius: '10px', border: '1px solid #1e293b' }}>
+                <h3 style={{ marginTop: 0, color: '#e2e8f0' }}>💰 Estimated Run Cost</h3>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5rem', flexWrap: 'wrap' }}>
+                  <span style={{ fontSize: '1.6rem', fontWeight: 700, color: '#fbbf24' }}>
+                    {result.solution_pricing.estimated_run_cost_usd === null
+                      ? 'Quote only'
+                      : `$${Number(result.solution_pricing.estimated_run_cost_usd).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}
+                  </span>
+                  <span style={{ color: '#94a3b8', fontSize: '0.85rem' }}>
+                    {result.solution_pricing.platform}
+                    {result.solution_pricing.provider ? ` · ${result.solution_pricing.provider}` : ''}
+                    {result.solution_pricing.sku ? ` · ${result.solution_pricing.sku}` : ''}
+                  </span>
+                </div>
+                {result.solution_pricing.basis && (
+                  <p style={{ color: '#94a3b8', fontSize: '0.82rem', margin: '0.5rem 0 0' }}>{result.solution_pricing.basis}</p>
+                )}
+                {typeof result.solution_pricing.feasible_today === 'boolean' && (
+                  <div style={{ marginTop: '0.6rem', padding: '0.4rem 0.8rem', borderRadius: '6px', fontSize: '0.85rem',
+                    background: result.solution_pricing.feasible_today ? '#064e3b' : '#7c2d12',
+                    color: result.solution_pricing.feasible_today ? '#6ee7b7' : '#fdba74' }}>
+                    {result.solution_pricing.feasible_today
+                      ? '✅ Runnable on today’s hardware'
+                      : `⏳ Not yet runnable: needs ~${Number(result.solution_pricing.qubits_needed || 0).toLocaleString()} qubits; current hardware exposes ${result.solution_pricing.qubits_available_today}`}
+                  </div>
+                )}
+                {result.solution_pricing.crossover_note && (
+                  <p style={{ color: '#64748b', fontSize: '0.78rem', margin: '0.5rem 0 0', fontStyle: 'italic' }}>
+                    {result.solution_pricing.crossover_note}
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## What

Adds the two requested post-code-gen steps to the evaluator: after a high-confidence platform recommendation + code generation, it now (1) draws the **solution architecture** as a Mermaid diagram and (2) **guesstimates the run cost** of that specific solution, including the qubit-availability crossover.

Tracked as a living initiative in `docs/initiatives/architecture-pricing.md` (improve piece by piece as new hardware ships).

## Backend

- **`agents/code_generator/architecture.py`** (new): deterministic, grounded Mermaid generator. Quantum diagrams name the real target QPU and qubit width (e.g., Quantinuum H2-1, 56 qubits); HPC/AI-ML diagrams show the CycleCloud/Foundry topology.
- **`agents/classifier/cost_model.py`** -> `price_solution()`: prices the *generated* solution using the actual code-gen resource estimate (physical_qubits, runtime_ns) instead of KB defaults, and surfaces the crossover via `quantum_hardware_feasibility` (`feasible_today`, `qubits_needed` vs `qubits_available_today`).
- **`agents/api/main.py`**: `/api/evaluate` now returns `architecture`, `architecture_diagram`, and `solution_pricing` when `generate_code=true` and confidence >= `QGC_ARCH_MIN_CONFIDENCE` (default 0.6).

## Frontend

- **`website/pages/evaluate.tsx`**: renders the Mermaid diagram client-side (falls back to the source text on any render error) plus a run-cost card with feasibility + crossover. Adds the `mermaid` dependency. Website build verified (25/25 pages, `/evaluate` compiles).

## Validated

- Pricing calculator confirmed working (Quantum H2 256 shots ~ $245, HPC A100 1hr ~ $27).
- Local test of the lithium cobalt oxide example -> grounded Mermaid (Quantinuum H2-1, QPE driver) + run cost with crossover ("needs ~180,000 qubits; device exposes 56; not feasible today").

## Deploy

Merging triggers both workflows: the API rebuild/redeploy (agents/** changed) and the website deploy (website/** changed). `QGC_USE_AGENT=1` persists across the API image update.

## Roadmap (in the tracking doc)

- Increment 2: agent-enriched architecture via Microsoft Learn MCP + Azure Architecture Center.
- Increment 3: cost-vs-qubit-count crossover curve.
- Ongoing: refresh `QUANTUM_HARDWARE_QUBITS` + provider rates as devices ship.