### PR TITLE
chore: sync dependency graph tracked count

### DIFF
--- a/docs/depgraph/graph.json
+++ b/docs/depgraph/graph.json
@@ -1,7 +1,7 @@
 {
   "repo_relative_root": ".",
   "counts": {
-    "tracked": 1184,
+    "tracked": 1183,
     "code_files": 216,
     "python": 164,
     "qsharp": 43,


### PR DESCRIPTION
Regenerate `docs/depgraph/graph.json` so its `tracked` count (1184 -> 1183) reflects the eval dump removed in #142. Keeps the drift check green. Candidates remain 0.